### PR TITLE
Created the new complete feature for managing departments

### DIFF
--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/security/HyperLinks.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/security/HyperLinks.java
@@ -20,6 +20,8 @@ public class HyperLinks {
     public static final String DEMO_VIEW = "/pages/registerUser/DemoView.xhtml";
     public static final String DEPARTMENTS_VIEW = "/pages/admin/departments/departmentsView.xhtml?faces-redirect=true";
     public static final String DEPARTMENT_FORM = "/pages/admin/departments/departmentForm.xhtml";
+    public static final String DEPARTMENT_DETAILS_VIEW = "/pages/admin/departments/departmentDetails.xhtml?faces-redirect=true";
+
 
     public static final String ROLE_FORM = "/pages/users/RoleForm.xhtml?faces-redirect=true";
 

--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/departments/DepartmentsView.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/departments/DepartmentsView.java
@@ -1,25 +1,19 @@
 package org.pahappa.systems.kpiTracker.views.departments;
 
-import com.googlecode.genericdao.search.Filter;
 import com.googlecode.genericdao.search.Search;
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.commons.lang3.StringUtils;
 import org.pahappa.systems.kpiTracker.core.services.DepartmentService;
 import org.pahappa.systems.kpiTracker.models.Department;
-import org.pahappa.systems.kpiTracker.security.UiUtils;
+import org.pahappa.systems.kpiTracker.security.HyperLinks;
 import org.pahappa.systems.kpiTracker.views.dialogs.DepartmentFormDialog;
 import org.primefaces.model.FilterMeta;
 import org.primefaces.model.SortMeta;
 import org.sers.webutils.client.views.presenters.PaginatedTableView;
 import org.sers.webutils.client.views.presenters.ViewPath;
-import org.sers.webutils.model.RecordStatus;
 import org.sers.webutils.model.exception.OperationFailedException;
 import org.sers.webutils.server.core.service.excel.reports.ExcelReport;
 import org.sers.webutils.server.core.utils.ApplicationContextProvider;
-import org.sers.webutils.server.core.utils.SystemCrashHandler;
-import org.sers.webutils.server.shared.SharedAppData;
-import org.springframework.web.servlet.support.RequestContext;
 
 import javax.annotation.PostConstruct;
 import javax.faces.application.FacesMessage;
@@ -27,112 +21,66 @@ import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ManagedProperty;
 import javax.faces.bean.ViewScoped;
 import javax.faces.context.FacesContext;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
 
 @ManagedBean(name = "departmentsView")
 @ViewScoped
-@ViewPath(path = "/pages/admin/departments/departmentsView.xhtml")
+@ViewPath(path = HyperLinks.DEPARTMENTS_VIEW)
 @Getter
 @Setter
 public class DepartmentsView extends PaginatedTableView<Department, DepartmentsView, DepartmentsView> {
 
+    private static final long serialVersionUID = 1L;
     private DepartmentService departmentService;
-    private String searchTerm;
 
-    // FIX: Inject the dialog bean so the view can access it.
     @ManagedProperty(value = "#{departmentFormDialog}")
     private DepartmentFormDialog departmentFormDialog;
 
     @PostConstruct
     public void init() {
         this.departmentService = ApplicationContextProvider.getBean(DepartmentService.class);
-        super.setMaximumresultsPerpage(10); // Sets the number of rows per page
+        super.setMaximumresultsPerpage(12);
         reloadFilterReset();
     }
 
-    @Override
     public void reloadFilterReset(){
-        super.setTotalRecords(departmentService.countInstances(new Search()));
-        try{
+        try {
             super.reloadFilterReset();
-        }catch(Exception e){
-            UiUtils.ComposeFailure("Error",e.getLocalizedMessage());
+        } catch (Exception e) {
+            FacesContext.getCurrentInstance().addMessage(null, new FacesMessage(FacesMessage.SEVERITY_ERROR, "Error", e.getMessage()));
         }
-
     }
 
-    /**
-     * This is the core method for lazy loading. It's called by the p:dataTable
-     * whenever it needs to fetch data (on page load, pagination, sorting, etc.).
-     */
     @Override
     public void reloadFromDB(int offset, int limit, Map<String, Object> filters) {
-        // FIX: Added a try-catch block to expose any hidden exceptions during data loading.
-        try {
-            Search search = new Search();
-            search.addFilterEqual("recordStatus", RecordStatus.ACTIVE);
-            search.setFirstResult(offset);
-            search.setMaxResults(limit);
-
-            if (StringUtils.isNotBlank(this.searchTerm)) {
-                search.addFilter(Filter.or(
-                        Filter.ilike("name", "%" + this.searchTerm + "%"),
-                        Filter.ilike("description", "%" + this.searchTerm + "%")
-                ));
-            }
-
-            super.setDataModels(this.departmentService.getInstances(search, offset, limit));
-            super.setTotalRecords(this.departmentService.countInstances(search));
-
-        } catch (Exception e) {
-            System.err.println("AN ERROR OCCURRED IN 'reloadFromDB':");
-            e.printStackTrace(); // This will print the full error to your server console.
-            FacesContext.getCurrentInstance().addMessage(null,
-                    new FacesMessage(FacesMessage.SEVERITY_ERROR, "Error loading data", e.getMessage()));
-        }
+        Search search = new Search().addSortDesc("dateCreated");
+        super.setTotalRecords(departmentService.countInstances(search));
+        super.setDataModels(departmentService.getInstances(search, offset, limit));
     }
 
     public void deleteDepartment(Department department) {
         try {
-            // This correctly uses the generic deleteInstance method
             this.departmentService.deleteInstance(department);
-            UiUtils.showMessageBox("Success", "Department deleted successfully.");
+            reloadFilterReset();
+            FacesContext.getCurrentInstance().addMessage(null,
+                    new FacesMessage(FacesMessage.SEVERITY_INFO, "Success", "Department deleted."));
         } catch (OperationFailedException e) {
-            UiUtils.ComposeFailure("Error", e.getLocalizedMessage());
-            SystemCrashHandler.reportSystemCrash(e, SharedAppData.getLoggedInUser());
+            FacesContext.getCurrentInstance().addMessage(null,
+                    new FacesMessage(FacesMessage.SEVERITY_ERROR, "Failed", e.getMessage()));
         }
-    }
-
-    /**
-     * This method is used by a search button to trigger a table refresh.
-     */
-    public void search() {
-        // The lazy table will automatically call reloadFromDB when its parent form is updated.
-        // This method is kept for explicit search button actions.
-    }
-
-    @Override
-    public List<ExcelReport> getExcelReportModels() {
-        return null; // Implement for Excel export if needed
-    }
-
-    @Override
-    public String getFileName() {
-        return null; // Implement for Excel export if needed
-    }
-
-    @Override
-    public void forEach(Consumer<? super Department> action) {
-        super.forEach(action);
     }
 
     @Override
     public List<Department> load(int first, int pageSize, Map<String, SortMeta> sortBy, Map<String, FilterMeta> filterBy) {
         reloadFromDB(first, pageSize, null);
+        this.setRowCount(super.getTotalRecords());
         return super.getDataModels();
     }
 
+    @Override
+    public List<ExcelReport> getExcelReportModels() { return null; }
+
+    @Override
+    public String getFileName() { return null; }
 }

--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/dialogs/DepartmentFormDialog.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/dialogs/DepartmentFormDialog.java
@@ -8,8 +8,6 @@ import org.pahappa.systems.kpiTracker.models.Department;
 import org.pahappa.systems.kpiTracker.models.security.EmployeeUser;
 import org.primefaces.PrimeFaces;
 import org.sers.webutils.client.views.presenters.DialogForm;
-import org.sers.webutils.model.exception.OperationFailedException;
-import org.sers.webutils.model.exception.ValidationFailedException;
 import org.sers.webutils.server.core.utils.ApplicationContextProvider;
 
 import javax.annotation.PostConstruct;
@@ -27,9 +25,10 @@ public class DepartmentFormDialog extends DialogForm<Department> {
 
     private transient DepartmentService departmentService;
     private transient EmployeeUserService employeeUserService;
-    private List<EmployeeUser> users; // For the dropdown
+    private List<EmployeeUser> users;
 
     public DepartmentFormDialog() {
+        // The first argument is the 'name' which is also the 'widgetVar'
         super("departmentFormDialogWidget", 600, 350);
     }
 
@@ -37,80 +36,56 @@ public class DepartmentFormDialog extends DialogForm<Department> {
     public void init() {
         this.departmentService = ApplicationContextProvider.getBean(DepartmentService.class);
         this.employeeUserService = ApplicationContextProvider.getBean(EmployeeUserService.class);
-        // Load the list of users once for the dropdown
         this.users = this.employeeUserService.getAllInstances();
     }
 
-    /**
-     * This method is called by the inherited save() method.
-     * It contains the core logic for saving the entity.
-     */
     @Override
-    public void persist() throws ValidationFailedException, OperationFailedException {
+    public void persist() throws Exception {
         this.departmentService.saveInstance(super.getModel());
     }
 
-    /**
-     * Resets the form to its initial state for a new entry.
-     */
+    @Override
+    public void save() {
+        try {
+            this.persist();
+            FacesContext.getCurrentInstance().addMessage(null,
+                    new FacesMessage(FacesMessage.SEVERITY_INFO, "Action Successful", "Department saved successfully."));
+            PrimeFaces.current().ajax().addCallbackParam("saved", true);
+        } catch (Exception e) {
+            FacesContext.getCurrentInstance().addMessage(null,
+                    new FacesMessage(FacesMessage.SEVERITY_ERROR, "Action Failed", e.getLocalizedMessage()));
+            PrimeFaces.current().ajax().addCallbackParam("saved", false);
+        }
+    }
+
     @Override
     public void resetModal() {
         super.resetModal();
         super.setModel(new Department());
     }
 
-    /**
-     * This is called by the framework when a model is set for editing.
-     */
     @Override
     public void setFormProperties() {
         super.setFormProperties();
     }
 
-    @Override
-    public void beanInit() {
-
-    }
-
-    @Override
-    public void pageLoadInit() {
-
-    }
-
-    // Explicitly override getModel to ensure proper access
+    // --- SOLUTION TO PropertyNotFoundException ---
+    // Explicitly override the getters and setters for the model.
+    // This makes them directly available to the bean and solves the proxy issue.
     @Override
     public Department getModel() {
         return super.getModel();
     }
 
-    // Explicitly override setModel to ensure proper access
     @Override
     public void setModel(Department model) {
         super.setModel(model);
     }
+    // --- END OF SOLUTION ---
 
     @Override
-    public void save(){
-        try {
-            this.persist(); // This calls the method below to do the actual saving
+    public void beanInit() {}
 
-            // Add a success message to the growl
-            FacesContext.getCurrentInstance().addMessage(null,
-                    new FacesMessage(FacesMessage.SEVERITY_INFO, "Action Successful", "Department saved successfully."));
-
-            // This parameter is used by the oncomplete attribute in the XHTML to know it can close the dialog.
-            PrimeFaces.current().ajax().addCallbackParam("validationFailed", false);
-
-        } catch (ValidationFailedException | OperationFailedException e) {
-            FacesContext.getCurrentInstance().addMessage(null,
-                    new FacesMessage(FacesMessage.SEVERITY_ERROR, "Action Failed", e.getLocalizedMessage()));
-            // This parameter tells the oncomplete in the XHTML to keep the dialog open.
-            PrimeFaces.current().ajax().addCallbackParam("validationFailed", true);
-        } catch (Exception e) {
-            FacesContext.getCurrentInstance().addMessage(null,
-                    new FacesMessage(FacesMessage.SEVERITY_FATAL, "A fatal error occurred", "See server logs for details."));
-            e.printStackTrace();
-            PrimeFaces.current().ajax().addCallbackParam("validationFailed", true);
-        }
-    }
+    @Override
+    public void pageLoadInit() {}
 }

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/admin/departments/departmentForm.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/admin/departments/departmentForm.xhtml
@@ -1,35 +1,37 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
-                xmlns:ui="http://java.sun.com/jsf/facelets"
                 xmlns:h="http://java.sun.com/jsf/html"
                 xmlns:f="http://java.sun.com/jsf/core"
-                xmlns:p="http://primefaces.org/ui">
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:ui="http://java.sun.com/jsf/facelets">
 
-    <p:dialog header="#{departmentFormDialog.name}" widgetVar="departmentFormDialogWidget"
+    <p:dialog header="Department Details" widgetVar="departmentFormDialogWidget"
               modal="true" id="departmentFormDialog" resizable="false" draggable="false"
-              width="#{departmentFormDialog.width}" height="#{departmentFormDialog.height}">
+              width="600">
         <h:form id="departmentForm">
-            <p:panelGrid columns="2" styleClass="ui-panelgrid-blank" style="width: 100%;">
-                <p:outputLabel for="name" value="Name:" />
-                <p:inputText id="name" value="#{departmentFormDialog.model.name}" required="true" style="width: 100%;"/>
+            <p:panelGrid columns="1" layout="grid" styleClass="ui-panelgrid-blank">
 
-                <p:outputLabel for="lead" value="Department Lead:" />
+                <p:outputLabel for="name" value="Department Name" />
+                <p:inputText id="name" value="#{departmentFormDialog.model.name}" required="true"/>
+
+                <p:outputLabel for="lead" value="Department Lead" />
                 <p:selectOneMenu id="lead" value="#{departmentFormDialog.model.departmentLead}"
-                                 converter="userConverter"
-                                 filter="true" filterMatchMode="contains" style="width: 100%;">
-                    <f:selectItem itemLabel="Select One" itemValue="#{null}" noSelectionOption="true"/>
+                                 converter="userConverter" filter="true" filterMatchMode="contains">
+                    <f:selectItem itemLabel="-- No Lead --" itemValue="#{null}" />
                     <f:selectItems value="#{departmentFormDialog.users}" var="user"
                                    itemLabel="#{user.fullName}" itemValue="#{user}" />
                 </p:selectOneMenu>
 
-                <p:outputLabel for="desc" value="Description:" />
-                <p:inputTextarea id="desc" value="#{departmentFormDialog.model.description}" rows="4" style="width: 100%;"/>
+                <p:outputLabel for="desc" value="Description" />
+                <p:inputTextarea id="desc" value="#{departmentFormDialog.model.description}" rows="4"/>
 
-                <f:facet name="footer">
-                    <p:commandButton value="Save" actionListener="#{departmentFormDialog.save()}"
-                                     update=":departmentsForm:departmentsTable :growl"
-                                     oncomplete="if(!args.validationFailed) { PF('departmentFormDialogWidget').hide(); PF('departmentsTableWidget').filter(); }" />
-                    <p:commandButton value="Cancel" oncomplete="PF('departmentFormDialogWidget').hide()" immediate="true" process="@this"/></f:facet>
             </p:panelGrid>
+            <div class="p-d-flex p-jc-end p-mt-3">
+                <p:commandButton value="Save" actionListener="#{departmentFormDialog.save()}"
+                                 update=":departmentsForm :growl"
+                                 oncomplete="if(args &amp;&amp; args.saved){ PF('departmentFormDialogWidget').hide(); }" />
+                <p:commandButton value="Cancel" oncomplete="PF('departmentFormDialogWidget').hide()"
+                                 immediate="true" process="@this" styleClass="ui-button-secondary p-ml-2"/>
+            </div>
         </h:form>
     </p:dialog>
 </ui:composition>

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/admin/departments/departmentsView.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/admin/departments/departmentsView.xhtml
@@ -6,72 +6,76 @@
                 template="/pages/californiatemplate/template.xhtml">
 
     <ui:define name="title">Manage Departments</ui:define>
+    <ui:define name="viewname">Departments</ui:define>
 
     <ui:define name="content">
+        <style type="text/css">
+            .department-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 1.5rem; }
+            .department-card { background: #ffffff; border-radius: 8px; box-shadow: 0 4px 12px rgba(0,0,0,0.08); transition: all 0.3s ease; position: relative; overflow: hidden; }
+            .department-card:hover { transform: translateY(-5px); box-shadow: 0 10px 20px rgba(0,0,0,0.12); }
+            .card-content { padding: 1.5rem; }
+            .card-header { font-size: 1.25rem; font-weight: 600; color: #333; margin-bottom: 0.5rem; }
+            .card-meta { font-size: 0.9rem; color: #777; margin-bottom: 1rem; display: flex; align-items: center; }
+            .card-meta .pi { margin-right: 0.5rem; }
+            .card-actions { position: absolute; top: 1rem; right: 1rem; display: flex; gap: 0.5rem; background-color: rgba(255,255,255,0.8); backdrop-filter: blur(4px); border-radius: 20px; padding: 5px; z-index: 2; }
+            .card-link-overlay { position: absolute; top: 0; left: 0; right: 0; bottom: 0; z-index: 1; text-decoration: none; }
+        </style>
+
         <div class="card">
             <h:form id="departmentsForm">
-                <p:dataTable id="departmentsTable" widgetVar="departmentsTableWidget" var="department" value="#{departmentsView.dataModels}" lazy="true"
-                             paginator="true" rows="#{departmentsView.maximumresultsPerpage}"
-                             rowKey="#{department.id}"
-                             paginatorPosition="bottom"
-                             emptyMessage="No departments found.">
+                <p:growl id="growl" showDetail="true" />
+                <div class="p-d-flex p-jc-between p-ai-center p-mb-3">
+                    <h:panelGroup>
+                        <span style="font-size: 1.5rem; font-weight: 600;">Departments</span>
+                        <p class="text-secondary">Manage all company departments</p>
+                    </h:panelGroup>
+                    <p:commandButton value="Add Department" icon="pi pi-plus" process="@this"
+                                     actionListener="#{departmentsView.departmentFormDialog.resetModal()}"
+                                     oncomplete="PF('departmentFormDialogWidget').show()"
+                                     update=":departmentForm"/>
+                </div>
 
-                    <f:facet name="header">
-                        <div class="ui-g">
-                            <div class="ui-g-6" style="text-align: left">
-                                Manage Departments
+                <p:dataView var="department" value="#{departmentsView}" lazy="true"
+                            layout="grid" styleClass="department-grid" paginator="true" rows="#{departmentsView.maximumresultsPerpage}"
+                            paginatorPosition="bottom" emptyMessage="No departments found.">
+
+                    <p:dataViewGridItem>
+                        <div class="department-card">
+                            <p:button styleClass="card-link-overlay" outcome="/pages/admin/departments/departmentDetails.xhtml">
+                                <f:param name="id" value="#{department.id}" />
+                            </p:button>
+                            <div class="card-content">
+                                <div class="card-header">#{department.name}</div>
+                                <div class="card-meta">
+                                    <i class="pi pi-user"/> Lead: #{department.departmentLead != null ? department.departmentLead.fullName : 'N/A'}
+                                </div>
+                                <div class="card-meta">
+                                    <i class="pi pi-users"/> Total Employees: 12 <!-- Placeholder -->
+                                </div>
                             </div>
-                            <div class="ui-g-6" style="text-align: right">
-                                <p:commandButton value="Add Department" icon="pi pi-plus" process="@this"
-                                                 actionListener="#{departmentFormDialog.resetModal}"
+                            <div class="card-actions">
+                                <p:commandButton icon="pi pi-pencil" title="Edit" styleClass="rounded-button ui-button-info ui-button-outlined"
+                                                 actionListener="#{departmentsView.departmentFormDialog.setModel(department)}"
                                                  oncomplete="PF('departmentFormDialogWidget').show()"
-                                                update=":departmentFormDialog">
-                                    <f:setPropertyActionListener value="#{null}"
-                                                                 target="#{departmentFormDialog.model}"/>
-                                    <p:ajax event="dialogReturn"
-                                            listener="#{departmentsView.reloadFilterReset}"
-                                            update="departmentsTable"/>
+                                                 update=":departmentForm" />
+
+                                <p:commandButton icon="pi pi-trash" title="Delete" styleClass="rounded-button ui-button-danger ui-button-outlined"
+                                                 actionListener="#{departmentsView.deleteDepartment(department)}"
+                                                 update="departmentsForm">
+                                    <p:confirm header="Confirmation" message="Are you sure you want to delete this department?" icon="pi pi-exclamation-triangle" />
                                 </p:commandButton>
                             </div>
                         </div>
-                    </f:facet>
+                    </p:dataViewGridItem>
+                </p:dataView>
 
-                    <p:column headerText="Name" sortBy="#{department.name}">
-                        <h:outputText value="#{department.name}" />
-                    </p:column>
-
-                    <p:column headerText="Department Lead" >
-
-                        <h:outputText value="#{department.departmentLead != null ? department.departmentLead.fullName : 'N/A'}" />
-                    </p:column>
-
-                    <p:column headerText="Description">
-                        <h:outputText value="#{department.description}" />
-                    </p:column>
-
-                    <p:column headerText="Actions" style="width:100px;text-align: center">
-                        <p:commandButton icon="pi pi-pencil" title="Edit"
-                                         actionListener="#{departmentsView.departmentFormDialog.setModel(department)}"
-                                         oncomplete="PF('departmentFormDialogWidget').show()"
-                                         update=":departmentFormDialog" >
-                        </p:commandButton>
-
-                        <p:commandButton icon="pi pi-trash" title="Delete"
-                                         actionListener="#{departmentsView.deleteDepartment(department)}"
-                                         update=" :departmentForm" >
-                            <p:confirm header="Confirmation" message="Are you sure you want to delete this department?" icon="pi pi-exclamation-triangle" />
-                        </p:commandButton>
-                    </p:column>
-                </p:dataTable>
-                <!-- FIX: Add the required confirmation dialog -->
-                <p:confirmDialog global="true" showEffect="fade" hideEffect="fade" responsive="true" width="350">
+                <p:confirmDialog global="true" showEffect="fade" hideEffect="fade">
                     <p:commandButton value="Yes" type="button" styleClass="ui-confirmdialog-yes" icon="pi pi-check" />
                     <p:commandButton value="No" type="button" styleClass="ui-confirmdialog-no ui-button-secondary" icon="pi pi-times" />
                 </p:confirmDialog>
             </h:form>
         </div>
 
-        <!-- Include the dialog form -->
         <ui:include src="departmentForm.xhtml" />
     </ui:define>
 </ui:composition>


### PR DESCRIPTION
feat(departments): Implemented Departments module with card view and details page

This commit introduces the complete Department management feature, aligning with the UI mockups and project architecture.

- Developed a responsive, card-based `departmentsView.xhtml` using `p:dataView` to replace the standard table.
- Created a new `departmentDetails.xhtml` page to display department-specific information, including summary stats and dummy performance charts.
- Implemented a `p:dialog` with a corresponding `@SessionScoped` bean (`DepartmentFormDialog`) for creating and editing departments.
- Added navigation between the list view and details view.
- Resolved multiple JSF lifecycle and PrimeFaces versioning issues to ensure stability.