### PR TITLE
feat(teams): Refactored full CRUD and card UI for Teams

### DIFF
--- a/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/EmployeeUserService.java
+++ b/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/EmployeeUserService.java
@@ -1,11 +1,25 @@
 package org.pahappa.systems.kpiTracker.core.services;
+
 import org.pahappa.systems.kpiTracker.core.services.base.GenericService;
 import org.pahappa.systems.kpiTracker.models.Department;
+import org.pahappa.systems.kpiTracker.models.Team;
 import org.pahappa.systems.kpiTracker.models.security.EmployeeUser;
 import org.sers.webutils.server.core.service.UserService;
 
 import java.util.List;
 
 public interface EmployeeUserService extends UserService, GenericService<EmployeeUser> {
+    /**
+     * Retrieves a list of all employees assigned to a specific department.
+     * @param department The department to search for.
+     * @return A list of EmployeeUser objects.
+     */
     List<EmployeeUser> getEmployeesInDepartment(Department department);
+
+    /**
+     * Retrieves a list of all employees assigned to a specific team.
+     * @param team The team to search for.
+     * @return A list of EmployeeUser objects.
+     */
+    List<EmployeeUser> getEmployeesInTeam(Team team);
 }

--- a/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/impl/EmployeeUserServiceImpl.java
+++ b/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/impl/EmployeeUserServiceImpl.java
@@ -4,6 +4,7 @@ import com.googlecode.genericdao.search.Search;
 import org.pahappa.systems.kpiTracker.core.dao.EmployeeUserDao;
 import org.pahappa.systems.kpiTracker.core.services.EmployeeUserService;
 import org.pahappa.systems.kpiTracker.models.Department;
+import org.pahappa.systems.kpiTracker.models.Team;
 import org.pahappa.systems.kpiTracker.models.security.EmployeeUser;
 import org.pahappa.systems.kpiTracker.models.security.PermissionConstants;
 import org.pahappa.systems.kpiTracker.utils.Validate;
@@ -123,5 +124,13 @@ public class EmployeeUserServiceImpl extends UserServiceImpl implements Employee
             return new java.util.ArrayList<>();
         }
         return employeeUserDao.search(new Search().addFilterEqual("department", department));
+    }
+
+    @Override
+    public List<EmployeeUser> getEmployeesInTeam(Team team) {
+        if (team == null) {
+            return new java.util.ArrayList<>();
+        }
+        return employeeUserDao.search(new Search().addFilterEqual("team", team));
     }
 }

--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/security/HyperLinks.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/security/HyperLinks.java
@@ -22,6 +22,10 @@ public class HyperLinks {
     public static final String DEPARTMENT_FORM = "/pages/admin/departments/departmentForm.xhtml";
     public static final String DEPARTMENT_DETAILS_VIEW = "/pages/admin/departments/departmentDetails.xhtml?faces-redirect=true";
 
+    public static final String TEAMS_VIEW = "/pages/admin/teams/teamsView.xhtml?faces-redirect=true";
+    public static final String TEAM_FORM = "/pages/admin/teams/teamForm.xhtml";
+    public static final String TEAM_DETAILS_VIEW = "/pages/admin/teams/teamDetails.xhtml?faces-redirect=true";
+
 
     public static final String ROLE_FORM = "/pages/users/RoleForm.xhtml?faces-redirect=true";
 

--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/teams/TeamDetailsView.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/teams/TeamDetailsView.java
@@ -1,0 +1,95 @@
+package org.pahappa.systems.kpiTracker.views.teams;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.pahappa.systems.kpiTracker.core.services.EmployeeUserService;
+import org.pahappa.systems.kpiTracker.core.services.TeamService;
+import org.pahappa.systems.kpiTracker.models.Team;
+import org.pahappa.systems.kpiTracker.models.security.EmployeeUser;
+import org.pahappa.systems.kpiTracker.security.HyperLinks;
+import org.primefaces.model.chart.DonutChartModel;
+import org.primefaces.model.chart.MeterGaugeChartModel;
+import org.sers.webutils.client.views.presenters.ViewPath;
+import org.sers.webutils.client.views.presenters.WebFormView;
+import org.sers.webutils.server.core.utils.ApplicationContextProvider;
+
+import javax.annotation.PostConstruct;
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.ViewScoped;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@ManagedBean(name = "teamDetailsView")
+@ViewScoped
+@Getter @Setter
+@ViewPath(path = HyperLinks.TEAM_DETAILS_VIEW)
+public class TeamDetailsView extends WebFormView<Team, TeamDetailsView, TeamView> {
+
+    private static final long serialVersionUID = 1L;
+    private transient TeamService teamService;
+    private transient EmployeeUserService employeeUserService;
+
+    private String teamId;
+    private Team team;
+    private List<EmployeeUser> teamMembers;
+
+    private DonutChartModel kpiPerformanceModel;
+    private MeterGaugeChartModel professionalRatingsModel;
+
+    @Override
+    @PostConstruct
+    public void beanInit() {
+        this.teamService = ApplicationContextProvider.getBean(TeamService.class);
+        this.employeeUserService = ApplicationContextProvider.getBean(EmployeeUserService.class);
+
+        this.kpiPerformanceModel = new DonutChartModel();
+        this.professionalRatingsModel = new MeterGaugeChartModel();
+    }
+
+    @Override
+    public void pageLoadInit() {
+        if (teamId != null) {
+            this.team = teamService.getInstanceByID(teamId);
+            if (this.team != null) {
+                this.teamMembers = employeeUserService.getEmployeesInTeam(this.team);
+                createDummyCharts();
+            }
+        }
+    }
+
+    private void createDummyCharts() {
+        // KPI Performance Chart
+        Map<String, Number> circle = new LinkedHashMap<>();
+        circle.put("Achieved", 85);
+        circle.put("Remaining", 15);
+        kpiPerformanceModel.addCircle(circle);
+        kpiPerformanceModel.setSeriesColors("4CAF50,E0E0E0");
+        kpiPerformanceModel.setShowDataLabels(false);
+        kpiPerformanceModel.setExtender("kpiPerformanceExtender");
+
+        // Professional Attributes Chart
+        List<Number> intervals = new ArrayList<>();
+        intervals.add(40);
+        intervals.add(70);
+        intervals.add(100);
+        professionalRatingsModel = new MeterGaugeChartModel(78, intervals);
+        professionalRatingsModel.setSeriesColors("F44336,FFC107,4CAF50");
+        professionalRatingsModel.setGaugeLabel("Avg. Rating");
+        professionalRatingsModel.setGaugeLabelPosition("bottom");
+        professionalRatingsModel.setShowTickLabels(false);
+    }
+
+    @Override
+    public void persist() throws Exception {}
+    @Override
+    public void resetModal() {}
+    @Override
+    public void setFormProperties() {}
+
+    @Override
+    public String getViewUrl() {
+        return HyperLinks.TEAMS_VIEW;
+    }
+}

--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/teams/TeamView.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/teams/TeamView.java
@@ -6,10 +6,9 @@ import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 import org.pahappa.systems.kpiTracker.core.services.TeamService;
-import org.pahappa.systems.kpiTracker.models.Department;
 import org.pahappa.systems.kpiTracker.models.Team;
 import org.pahappa.systems.kpiTracker.models.security.PermissionConstants;
-import org.pahappa.systems.kpiTracker.security.UiUtils;
+import org.pahappa.systems.kpiTracker.security.HyperLinks;
 import org.pahappa.systems.kpiTracker.views.dialogs.TeamFormDialog;
 import org.primefaces.model.FilterMeta;
 import org.primefaces.model.SortMeta;
@@ -18,10 +17,8 @@ import org.sers.webutils.client.views.presenters.ViewPath;
 import org.sers.webutils.model.RecordStatus;
 import org.sers.webutils.model.exception.OperationFailedException;
 import org.sers.webutils.model.exception.SessionExpiredException;
-import org.sers.webutils.model.security.User;
+import org.sers.webutils.server.core.service.excel.reports.ExcelReport;
 import org.sers.webutils.server.core.utils.ApplicationContextProvider;
-import org.sers.webutils.server.core.utils.SystemCrashHandler;
-import org.sers.webutils.server.shared.SharedAppData;
 
 import javax.annotation.PostConstruct;
 import javax.faces.application.FacesMessage;
@@ -35,105 +32,86 @@ import java.util.Map;
 
 @ManagedBean(name = "teamsView")
 @ViewScoped
-@ViewPath(path = "/pages/admin/teams/teamsView.xhtml")
+@ViewPath(path = HyperLinks.TEAMS_VIEW)
+@Getter @Setter
 public class TeamView extends PaginatedTableView<Team, TeamView, TeamView> {
 
+    private static final long serialVersionUID = 1L;
     private TeamService teamService;
-    // Getters and Setters
-    @Getter
-    @Setter
     private String searchTerm;
 
-    @Getter
-    @Setter
     @ManagedProperty("#{teamFormDialog}")
     private TeamFormDialog teamFormDialog;
 
     @PostConstruct
     public void init() {
         this.teamService = ApplicationContextProvider.getBean(TeamService.class);
-        super.setMaximumresultsPerpage(10);
+        super.setMaximumresultsPerpage(12);
         try {
             super.enforceSecurity(null, true, new String[]{PermissionConstants.PERM_VIEW_TEAMS});
         } catch (SessionExpiredException | IOException e) {
-            try {
-                SystemCrashHandler.reportSystemCrash(e, User.class.newInstance());
-            } catch (InstantiationException | IllegalAccessException ex ) {
-                throw new RuntimeException(ex);
-            }
+            e.printStackTrace();
         }
         reloadFilterReset();
     }
 
-
     @Override
     public void reloadFilterReset() {
-        // Set the total records for pagination before loading data
-        Search search = new Search();
-        if (StringUtils.isNotBlank(this.searchTerm)) {
-            search.addFilter(Filter.or(
-                    Filter.ilike("name", "%" + this.searchTerm + "%"),
-                    Filter.ilike("description", "%" + this.searchTerm + "%")
-            ));
-        }
-        super.setTotalRecords(teamService.countInstances(search));
         try {
             super.reloadFilterReset();
         } catch (Exception e) {
-            UiUtils.ComposeFailure("Error", e.getLocalizedMessage());
+            FacesContext.getCurrentInstance().addMessage(null, new FacesMessage(FacesMessage.SEVERITY_ERROR, "Error", e.getLocalizedMessage()));
         }
     }
 
     @Override
     public void reloadFromDB(int offset, int limit, Map<String, Object> filters) {
-        try {
-            Search search = new Search();
-            search.addFilterEqual("recordStatus", RecordStatus.ACTIVE);
-            search.setFirstResult(offset);
-            search.setMaxResults(limit);
+        Search search = new Search();
+        search.addFilterEqual("recordStatus", RecordStatus.ACTIVE);
+        search.setFirstResult(offset);
+        search.setMaxResults(limit);
+        search.addSortDesc("dateCreated");
 
-            // CONSISTENCY: Added search term filter to match DepartmentsView logic
-            if (StringUtils.isNotBlank(this.searchTerm)) {
-                search.addFilter(Filter.or(
-                        Filter.ilike("name", "%" + this.searchTerm + "%"),
-                        Filter.ilike("description", "%" + this.searchTerm + "%")
-                ));
-            }
-
-            super.setDataModels(this.teamService.getInstances(search, offset, limit));
-            // CONSISTENCY: Update total records based on the current search
-            super.setTotalRecords(this.teamService.countInstances(search));
-
-        } catch (Exception e) {
-            System.err.println("AN ERROR OCCURRED IN 'reloadFromDB' for TeamView:");
-            e.printStackTrace();
-            FacesContext.getCurrentInstance().addMessage(null,
-                    new FacesMessage(FacesMessage.SEVERITY_ERROR, "Error loading teams", e.getMessage()));
+        if (StringUtils.isNotBlank(this.searchTerm)) {
+            search.addFilter(Filter.or(
+                    Filter.ilike("name", "%" + this.searchTerm + "%"),
+                    Filter.ilike("description", "%" + this.searchTerm + "%"),
+                    Filter.ilike("department.name", "%" + this.searchTerm + "%")
+            ));
         }
+
+        super.setTotalRecords(this.teamService.countInstances(search));
+        super.setDataModels(this.teamService.getInstances(search, offset, limit));
     }
 
     @Override
-    public List<org.sers.webutils.server.core.service.excel.reports.ExcelReport> getExcelReportModels() { return null; }
+    public List<ExcelReport> getExcelReportModels() { return null; }
+
     @Override
     public String getFileName() { return null; }
 
+    // THIS IS THE CORRECTED METHOD
     @Override
     public List<Team> load(int first, int pageSize, Map<String, SortMeta> sortBy, Map<String, FilterMeta> filterBy) {
         try {
             reloadFromDB(first, pageSize, null);
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            FacesContext.getCurrentInstance().addMessage(null, new FacesMessage(FacesMessage.SEVERITY_ERROR, "Data Error", "Failed to load data."));
+            e.printStackTrace();
         }
+        this.setRowCount(super.getTotalRecords());
         return super.getDataModels();
     }
 
     public void deleteTeam(Team team) {
         try {
             this.teamService.deleteInstance(team);
-            // FIX: Use UiUtils to show messages, as the base class doesn't have these methods.
+            reloadFilterReset();
+            FacesContext.getCurrentInstance().addMessage(null,
+                    new FacesMessage(FacesMessage.SEVERITY_INFO, "Success", "Team deleted successfully."));
         } catch (OperationFailedException e) {
-            // FIX: Use UiUtils for error messages and log the exception.
-            SystemCrashHandler.reportSystemCrash(e, SharedAppData.getLoggedInUser());
+            FacesContext.getCurrentInstance().addMessage(null,
+                    new FacesMessage(FacesMessage.SEVERITY_ERROR, "Failed", e.getLocalizedMessage()));
         }
     }
 }

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/admin/departments/departmentsView.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/admin/departments/departmentsView.xhtml
@@ -10,83 +10,772 @@
 
     <ui:define name="content">
         <style type="text/css">
-            .page-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; }
-            .page-title { font-size: 1.5rem; font-weight: 600; }
-            .page-subtitle { color: #6c757d; }
-            .department-grid-container .ui-dataview-content { border: none; background: transparent; }
-            .department-card { background: #ffffff; border-radius: 8px; box-shadow: 0 4px 6px rgba(0,0,0,0.05); transition: all 0.2s ease-in-out; position: relative; margin-bottom: 1.5rem; }
-            .department-card:hover { transform: translateY(-4px); box-shadow: 0 8px 16px rgba(0,0,0,0.1); }
-            .card-content { padding: 1.25rem; }
-            .card-header-text { font-size: 1.1rem; font-weight: 600; color: #343a40; margin-bottom: 0.5rem; }
-            .card-meta-text { font-size: 0.875rem; color: #6c757d; margin-bottom: 1.25rem; }
-            .card-actions { border-top: 1px solid #e9ecef; padding: 0.75rem 1.25rem; display: flex; justify-content: space-between; align-items: center; }
-            .card-edit-link { color: #007bff; text-decoration: none; font-weight: 500; font-size: 0.875rem; }
-            .card-link-overlay { position: absolute; top:0; left:0; right:0; bottom: 60px; z-index: 1; }
+            :root {
+                --pahappa-blue: #2155A3;
+                --pahappa-green: #6DBE46;
+                --light-blue: #e3f2fd;
+                --light-green: #f1f8e9;
+                --gradient-primary: linear-gradient(135deg, var(--pahappa-blue), #1e4a8c);
+                --gradient-secondary: linear-gradient(135deg, var(--pahappa-green), #5da83d);
+                --shadow-soft: 0 4px 20px rgba(33, 85, 163, 0.08);
+                --shadow-hover: 0 8px 32px rgba(33, 85, 163, 0.15);
+                --border-radius: 12px;
+                --transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+            }
+
+            .departments-container {
+                background: transparent;
+                min-height: calc(100vh - 80px);
+                padding: 2rem 0;
+            }
+
+            .content-wrapper {
+                max-width: 1400px;
+                margin: 0 auto;
+                padding: 0 1.5rem;
+            }
+
+            .page-header {
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
+                margin-bottom: 2.5rem;
+                background: transparent;
+                padding: 2rem;
+                border-radius: var(--border-radius);
+                box-shadow: var(--shadow-soft);
+                position: relative;
+                overflow: hidden;
+            }
+
+            .page-header::before {
+                content: '';
+                position: absolute;
+                top: 0;
+                left: 0;
+                right: 0;
+                height: 4px;
+                background: var(--gradient-primary);
+            }
+
+            .page-title {
+                font-size: 2rem;
+                font-weight: 700;
+                color: var(--pahappa-blue);
+                margin-bottom: 0.25rem;
+                background: var(--gradient-primary);
+                -webkit-background-clip: text;
+                -webkit-text-fill-color: transparent;
+                background-clip: text;
+            }
+
+            .page-subtitle {
+                color: #64748b;
+                font-size: 1rem;
+                font-weight: 500;
+            }
+
+            .header-actions {
+                display: flex;
+                align-items: center;
+                gap: 1rem;
+            }
+
+            .search-container {
+                position: relative;
+            }
+
+            .search-container .ui-inputtext {
+                padding: 0.75rem 1rem 0.75rem 2.5rem;
+                border: 2px solid #e2e8f0;
+                border-radius: 50px;
+                font-size: 0.95rem;
+                transition: var(--transition);
+                width: 280px;
+                background: white;
+            }
+
+            .search-container .ui-inputtext:focus {
+                border-color: var(--pahappa-blue);
+                box-shadow: 0 0 0 3px rgba(33, 85, 163, 0.1);
+                outline: none;
+            }
+
+            .search-container .pi-search {
+                position: absolute;
+                left: 1rem;
+                top: 50%;
+                transform: translateY(-50%);
+                color: #94a3b8;
+                z-index: 2;
+            }
+
+            .add-department-btn {
+                background: var(--gradient-primary) !important;
+                border: none !important;
+                padding: 0.75rem 1.5rem !important;
+                border-radius: 50px !important;
+                font-weight: 600 !important;
+                font-size: 0.95rem !important;
+                transition: var(--transition) !important;
+                box-shadow: var(--shadow-soft) !important;
+            }
+
+            .add-department-btn:hover {
+                transform: translateY(-2px) !important;
+                box-shadow: var(--shadow-hover) !important;
+            }
+
+            .department-grid-container {
+                margin-top: 1rem;
+            }
+
+            .department-grid-container .ui-dataview-content {
+                border: none;
+                background: transparent;
+                padding: 0;
+            }
+
+            .department-card {
+                background: transparent;
+                border-radius: var(--border-radius);
+                box-shadow: var(--shadow-soft);
+                transition: var(--transition);
+                position: relative;
+                margin-bottom: 1.5rem;
+                overflow: hidden;
+                height: 100%;
+                border: 1px solid #f1f5f9;
+            }
+
+            .department-card::before {
+                content: '';
+                position: absolute;
+                top: 0;
+                left: 0;
+                right: 0;
+                height: 4px;
+                background: var(--gradient-secondary);
+                opacity: 0;
+                transition: var(--transition);
+            }
+
+            .department-card:hover {
+                transform: translateY(-8px);
+                box-shadow: var(--shadow-hover);
+                border-color: var(--pahappa-green);
+            }
+
+            .department-card:hover::before {
+                opacity: 1;
+            }
+
+            .card-content {
+                padding: 2rem 1.5rem 1.5rem;
+                position: relative;
+            }
+
+            .card-icon {
+                position: absolute;
+                top: 1.5rem;
+                right: 1.5rem;
+                width: 48px;
+                height: 48px;
+                background: var(--light-blue);
+                border-radius: 50%;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                color: var(--pahappa-blue);
+                font-size: 1.2rem;
+            }
+
+            .card-header-text {
+                font-size: 1.3rem;
+                font-weight: 700;
+                color: #1e293b;
+                margin-bottom: 1rem;
+                line-height: 1.3;
+                padding-right: 60px;
+            }
+
+            .card-meta-container {
+                display: flex;
+                flex-direction: column;
+                gap: 0.75rem;
+                margin-bottom: 1.5rem;
+            }
+
+            .card-meta-item {
+                display: flex;
+                align-items: center;
+                gap: 0.75rem;
+                padding: 0.5rem;
+                background: #f8fafc;
+                border-radius: 8px;
+                transition: var(--transition);
+            }
+
+            .card-meta-item:hover {
+                background: var(--light-blue);
+            }
+
+            .card-meta-icon {
+                width: 32px;
+                height: 32px;
+                background: var(--gradient-primary);
+                border-radius: 6px;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                color: white;
+                font-size: 0.85rem;
+                flex-shrink: 0;
+            }
+
+            .card-meta-text {
+                font-size: 0.9rem;
+                color: #475569;
+                font-weight: 500;
+                margin: 0;
+            }
+
+            .card-actions {
+                border-top: 1px solid #f1f5f9;
+                padding: 1rem 1.5rem;
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
+                background: #fafbfc;
+            }
+
+            .card-edit-btn {
+                background: var(--gradient-secondary) !important;
+                border: none !important;
+                color: white !important;
+                padding: 0.5rem 1rem !important;
+                border-radius: 6px !important;
+                font-weight: 600 !important;
+                font-size: 0.85rem !important;
+                transition: var(--transition) !important;
+            }
+
+            .card-edit-btn:hover {
+                transform: translateY(-1px) !important;
+                box-shadow: 0 4px 12px rgba(109, 190, 70, 0.3) !important;
+            }
+
+            .card-delete-btn {
+                background: linear-gradient(135deg, #ef4444, #dc2626) !important;
+                border: none !important;
+                padding: 0.5rem !important;
+                border-radius: 6px !important;
+                transition: var(--transition) !important;
+                width: 36px !important;
+                height: 36px !important;
+            }
+
+            .card-delete-btn:hover {
+                transform: translateY(-1px) !important;
+                box-shadow: 0 4px 12px rgba(239, 68, 68, 0.3) !important;
+            }
+
+            .card-link-overlay {
+                position: absolute;
+                top: 0;
+                left: 0;
+                right: 0;
+                bottom: 65px;
+                z-index: 1;
+            }
+
+            .department-stats {
+                display: grid;
+                grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+                gap: 1.5rem;
+                margin-bottom: 2rem;
+            }
+
+            .stat-card {
+                background: white;
+                padding: 1.5rem;
+                border-radius: var(--border-radius);
+                box-shadow: var(--shadow-soft);
+                display: flex;
+                align-items: center;
+                gap: 1rem;
+                transition: var(--transition);
+            }
+
+            .stat-card:hover {
+                transform: translateY(-2px);
+                box-shadow: var(--shadow-hover);
+            }
+
+            .stat-icon {
+                width: 48px;
+                height: 48px;
+                border-radius: 50%;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                font-size: 1.2rem;
+                color: white;
+            }
+
+            .stat-icon.total { background: var(--gradient-primary); }
+            .stat-icon.active { background: var(--gradient-secondary); }
+
+            .stat-content h3 {
+                font-size: 1.5rem;
+                font-weight: 700;
+                margin: 0 0 0.25rem 0;
+                color: #1e293b;
+            }
+
+            .stat-content p {
+                font-size: 0.9rem;
+                color: #64748b;
+                margin: 0;
+                font-weight: 500;
+            }
+
+            .empty-state {
+                text-align: center;
+                padding: 4rem 2rem;
+                background: white;
+                border-radius: var(--border-radius);
+                box-shadow: var(--shadow-soft);
+            }
+
+            .empty-state-icon {
+                width: 80px;
+                height: 80px;
+                background: var(--light-blue);
+                border-radius: 50%;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                margin: 0 auto 1.5rem;
+                color: var(--pahappa-blue);
+                font-size: 2rem;
+            }
+
+            .empty-state h3 {
+                font-size: 1.3rem;
+                font-weight: 600;
+                color: #1e293b;
+                margin-bottom: 0.5rem;
+            }
+
+            .empty-state p {
+                color: #64748b;
+                font-size: 1rem;
+            }
+
+            /* Loading Animation */
+            .loading-skeleton {
+                background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
+                background-size: 200% 100%;
+                animation: loading 1.5s infinite;
+            }
+
+            @keyframes loading {
+                0% { background-position: 200% 0; }
+                100% { background-position: -200% 0; }
+            }
+
+            /* Responsive Design */
+            @media (max-width: 768px) {
+                .page-header {
+                    flex-direction: column;
+                    align-items: stretch;
+                    gap: 1.5rem;
+                }
+
+                .header-actions {
+                    justify-content: center;
+                }
+
+                .search-container .ui-inputtext {
+                    width: 100%;
+                }
+
+                .card-content {
+                    padding: 1.5rem 1rem;
+                }
+
+                .card-icon {
+                    position: static;
+                    margin-bottom: 1rem;
+                }
+
+                .card-header-text {
+                    padding-right: 0;
+                }
+            }
+
+            /* Animation Classes */
+            .fade-in {
+                animation: fadeIn 0.6s ease-out;
+            }
+
+            @keyframes fadeIn {
+                from { opacity: 0; transform: translateY(20px); }
+                to { opacity: 1; transform: translateY(0); }
+            }
         </style>
 
-        <div class="card">
-            <h:form id="departmentsForm">
-                <p:growl id="growl" showDetail="true" />
-                <div class="page-header">
-                    <div>
-                        <div class="page-title">Departments List</div>
-                        <div class="page-subtitle">Manage all company departments</div>
+        <div class="departments-container">
+            <div class="content-wrapper">
+                <h:form id="departmentsForm">
+                    <p:growl id="growl" showDetail="true" />
+
+                    <div class="page-header fade-in">
+                        <div>
+                            <div class="page-title">Departments</div>
+                            <div class="page-subtitle">Manage all company departments and teams</div>
+                        </div>
+                        <div class="header-actions">
+                            <div class="search-container">
+                                <i class="pi pi-search" />
+                                <p:inputText value="#{departmentsView.searchTerm}"
+                                             placeholder="Search departments..."
+                                             styleClass="search-input">
+                                    <p:ajax event="keyup" update="departmentsDataView" />
+                                </p:inputText>
+                            </div>
+                            <p:commandButton value="Add Department"
+                                             icon="pi pi-plus"
+                                             process="@this"
+                                             styleClass="add-department-btn"
+                                             actionListener="#{departmentFormDialog.resetModal()}"
+                                             oncomplete="PF('departmentFormDialogWidget').show()"
+                                             update=":departmentForm"/>
+                        </div>
                     </div>
-                    <div class="p-d-flex p-ai-center">
-                         <span class="ui-input-icon-left p-mr-2">
-                            <i class="pi pi-search" />
-                            <p:inputText value="#{departmentsView.searchTerm}" placeholder="Search..." >
-                                <p:ajax event="keyup" update="departmentsDataView" />
-                            </p:inputText>
-                        </span>
-                        <p:commandButton value="Add Department" icon="pi pi-plus" process="@this"
-                                         actionListener="#{departmentFormDialog.resetModal()}"
-                                         oncomplete="PF('departmentFormDialogWidget').show()"
-                                         update=":departmentForm"/>
-                    </div>
-                </div>
 
-
-                <p:dataView id="departmentsDataView" var="department" value="#{departmentsView}" lazy="true"
-                            layout="grid" gridIcon="pi pi-th-large" listIcon="pi pi-bars"
-                            paginator="true" rows="#{departmentsView.maximumresultsPerpage}"
-                            paginatorPosition="bottom" emptyMessage="No departments found."
-                            styleClass="department-grid-container">
-
-                    <p:dataViewGridItem>
-                        <div class="p-col-12 p-md-4">
-                            <div class="department-card">
-                                <div class="card-content">
-                                    <div class="card-header-text">#{department.name}</div>
-                                    <div class="card-meta-text">Total 12 Employees</div> <!-- Placeholder -->
-                                    <div class="card-meta-text">Lead: #{department.departmentLead != null ? department.departmentLead.fullName : 'N/A'}</div>
-                                </div>
-                                <div class="card-actions">
-                                    <p:commandButton value="Edit" styleClass="ui-button-text card-edit-link"
-                                                     actionListener="#{departmentsView.departmentFormDialog.setModel(department)}"
-                                                     oncomplete="PF('departmentFormDialogWidget').show()"
-                                                     update=":departmentForm"/>
-
-                                    <p:commandButton icon="pi pi-trash" title="Delete" styleClass="ui-button-text ui-button-danger"
-                                                     actionListener="#{departmentsView.deleteDepartment(department)}"
-                                                     update="@form">
-                                        <p:confirm header="Confirmation" message="Are you sure you want to delete this department?" icon="pi pi-exclamation-triangle" />
-                                    </p:commandButton>
-                                </div>
-                                <h:link outcome="/pages/admin/departments/departmentDetails.xhtml?faces-redirect=true" styleClass="card-link-overlay">
-                                    <f:param name="id" value="#{department.id}"/>
-                                </h:link>
+                    <div class="department-stats fade-in">
+                        <div class="stat-card">
+                            <div class="stat-icon total">
+                                <i class="pi pi-building"></i>
+                            </div>
+                            <div class="stat-content">
+                                <h3 id="totalDepartments">0</h3>
+                                <p>Total Departments</p>
                             </div>
                         </div>
-                    </p:dataViewGridItem>
-                </p:dataView>
+                        <div class="stat-card">
+                            <div class="stat-icon active">
+                                <i class="pi pi-users"></i>
+                            </div>
+                            <div class="stat-content">
+                                <h3 id="totalEmployees">0</h3>
+                                <p>Total Employees</p>
+                            </div>
+                        </div>
+                    </div>
 
-                <p:confirmDialog global="true" showEffect="fade" hideEffect="fade">
-                    <p:commandButton value="Yes" type="button" styleClass="ui-confirmdialog-yes" icon="pi pi-check" />
-                    <p:commandButton value="No" type="button" styleClass="ui-confirmdialog-no ui-button-secondary" icon="pi pi-times" />
-                </p:confirmDialog>
-            </h:form>
+                    <p:dataView id="departmentsDataView"
+                                var="department"
+                                value="#{departmentsView}"
+                                lazy="true"
+                                layout="grid"
+                                gridIcon="pi pi-th-large"
+                                listIcon="pi pi-bars"
+                                paginator="true"
+                                rows="#{departmentsView.maximumresultsPerpage}"
+                                paginatorPosition="bottom"
+                                emptyMessage="No departments found."
+                                styleClass="department-grid-container">
+
+                        <p:dataViewGridItem>
+                            <div class="p-col-12 p-md-6 p-lg-4">
+                                <div class="department-card fade-in">
+                                    <div class="card-content">
+                                        <div class="card-icon">
+                                            <i class="pi pi-building"></i>
+                                        </div>
+                                        <div class="card-header-text">#{department.name}</div>
+                                        <div class="card-meta-container">
+                                            <div class="card-meta-item">
+                                                <div class="card-meta-icon">
+                                                    <i class="pi pi-users"></i>
+                                                </div>
+                                                <div class="card-meta-text">12 Employees</div> <!-- Placeholder -->
+                                            </div>
+                                            <div class="card-meta-item">
+                                                <div class="card-meta-icon">
+                                                    <i class="pi pi-user"></i>
+                                                </div>
+                                                <div class="card-meta-text">
+                                                    Lead: #{department.departmentLead != null ? department.departmentLead.fullName : 'Not Assigned'}
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="card-actions">
+                                        <p:commandButton value="Edit Department"
+                                                         styleClass="card-edit-btn"
+                                                         actionListener="#{departmentsView.departmentFormDialog.setModel(department)}"
+                                                         oncomplete="PF('departmentFormDialogWidget').show()"
+                                                         update=":departmentForm"/>
+
+                                        <p:commandButton icon="pi pi-trash"
+                                                         title="Delete Department"
+                                                         styleClass="card-delete-btn"
+                                                         actionListener="#{departmentsView.deleteDepartment(department)}"
+                                                         update="@form">
+                                            <p:confirm header="Delete Confirmation"
+                                                       message="Are you sure you want to delete this department? This action cannot be undone."
+                                                       icon="pi pi-exclamation-triangle" />
+                                        </p:commandButton>
+                                    </div>
+                                    <h:link outcome="/pages/admin/departments/departmentDetails.xhtml?faces-redirect=true"
+                                            styleClass="card-link-overlay">
+                                        <f:param name="id" value="#{department.id}"/>
+                                    </h:link>
+                                </div>
+                            </div>
+                        </p:dataViewGridItem>
+
+                        <f:facet name="empty">
+                            <div class="empty-state fade-in">
+                                <div class="empty-state-icon">
+                                    <i class="pi pi-building"></i>
+                                </div>
+                                <h3>No Departments Found</h3>
+                                <p>Get started by creating your first department</p>
+                            </div>
+                        </f:facet>
+                    </p:dataView>
+
+                    <p:confirmDialog global="true" showEffect="fade" hideEffect="fade" responsive="true">
+                        <p:commandButton value="Yes, Delete" type="button"
+                                         styleClass="ui-confirmdialog-yes ui-button-danger"
+                                         icon="pi pi-check" />
+                        <p:commandButton value="Cancel" type="button"
+                                         styleClass="ui-confirmdialog-no ui-button-secondary"
+                                         icon="pi pi-times" />
+                    </p:confirmDialog>
+                </h:form>
+            </div>
         </div>
+
+        <script type="text/javascript">
+            // Enhanced JavaScript functionality
+            document.addEventListener('DOMContentLoaded', function() {
+                // Initialize animations and interactions
+                initializeDepartmentPage();
+            });
+
+            function initializeDepartmentPage() {
+                // Add loading animation for better UX
+                addLoadingAnimation();
+
+                // Update statistics
+                updateDepartmentStats();
+
+                // Add smooth scrolling
+                addSmoothScrolling();
+
+                // Initialize tooltips
+                initializeTooltips();
+
+                // Add keyboard navigation
+                addKeyboardNavigation();
+            }
+
+            function addLoadingAnimation() {
+                const dataView = document.querySelector('[id$="departmentsDataView"]');
+                if (dataView) {
+                    const observer = new MutationObserver(function(mutations) {
+                        mutations.forEach(function(mutation) {
+                            if (mutation.type === 'childList') {
+                                const newCards = mutation.target.querySelectorAll('.department-card:not(.animated)');
+                                newCards.forEach((card, index) => {
+                                    card.classList.add('animated');
+                                    setTimeout(() => {
+                                        card.style.opacity = '1';
+                                        card.style.transform = 'translateY(0)';
+                                    }, index * 100);
+                                });
+                            }
+                        });
+                    });
+                    observer.observe(dataView, { childList: true, subtree: true });
+                }
+            }
+
+            function updateDepartmentStats() {
+                // Count departments
+                setTimeout(() => {
+                    const departmentCards = document.querySelectorAll('.department-card');
+                    const totalDepartments = departmentCards.length;
+                    const totalEmployeesElement = document.getElementById('totalEmployees');
+                    const totalDepartmentsElement = document.getElementById('totalDepartments');
+
+                    if (totalDepartmentsElement) {
+                        animateNumber(totalDepartmentsElement, 0, totalDepartments, 1000);
+                    }
+
+                    // Calculate total employees (placeholder - you can enhance this)
+                    let totalEmployees = totalDepartments * 12; // Assuming 12 employees per dept on average
+                    if (totalEmployeesElement) {
+                        animateNumber(totalEmployeesElement, 0, totalEmployees, 1500);
+                    }
+                }, 500);
+            }
+
+            function animateNumber(element, start, end, duration) {
+                const startTime = performance.now();
+                const animate = (currentTime) => {
+                    const elapsed = currentTime - startTime;
+                    const progress = Math.min(elapsed / duration, 1);
+                    const easeOutCubic = 1 - Math.pow(1 - progress, 3);
+                    const current = Math.floor(start + (end - start) * easeOutCubic);
+                    element.textContent = current;
+
+                    if (!(progress >= 1)) {
+                        requestAnimationFrame(animate);
+                    }
+                };
+                requestAnimationFrame(animate);
+            }
+
+            function addSmoothScrolling() {
+                document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+                    anchor.addEventListener('click', function (e) {
+                        e.preventDefault();
+                        const target = document.querySelector(this.getAttribute('href'));
+                        if (target) {
+                            target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                        }
+                    });
+                });
+            }
+
+            function initializeTooltips() {
+                const tooltipElements = document.querySelectorAll('[title]');
+                tooltipElements.forEach(element => {
+                    element.addEventListener('mouseenter', showTooltip);
+                    element.addEventListener('mouseleave', hideTooltip);
+                });
+            }
+
+            function showTooltip(event) {
+                const element = event.target;
+                const title = element.getAttribute('title');
+                if (!title) return;
+
+                const tooltip = document.createElement('div');
+                tooltip.className = 'custom-tooltip';
+                tooltip.textContent = title;
+                tooltip.style.cssText = `
+                    position: absolute;
+                    background: #1e293b;
+                    color: white;
+                    padding: 0.5rem 0.75rem;
+                    border-radius: 6px;
+                    font-size: 0.875rem;
+                    z-index: 1000;
+                    pointer-events: none;
+                    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+                    transition: opacity 0.2s ease;
+                `;
+
+                document.body.appendChild(tooltip);
+                element.removeAttribute('title');
+                element.setAttribute('data-original-title', title);
+
+                const updatePosition = (e) => {
+                    tooltip.style.left = (e.pageX + 10) + 'px';
+                    tooltip.style.top = (e.pageY - tooltip.offsetHeight - 10) + 'px';
+                };
+
+                element.addEventListener('mousemove', updatePosition);
+                updatePosition(event);
+            }
+
+            function hideTooltip(event) {
+                const element = event.target;
+                const tooltip = document.querySelector('.custom-tooltip');
+                if (tooltip) {
+                    tooltip.remove();
+                }
+
+                const originalTitle = element.getAttribute('data-original-title');
+                if (originalTitle) {
+                    element.setAttribute('title', originalTitle);
+                    element.removeAttribute('data-original-title');
+                }
+            }
+
+            function addKeyboardNavigation() {
+                document.addEventListener('keydown', function(e) {
+                    // ESC key to close modals
+                    if (e.key === 'Escape') {
+                        const activeModal = document.querySelector('.ui-dialog:not(.ui-helper-hidden)');
+                        if (activeModal) {
+                            const closeButton = activeModal.querySelector('.ui-dialog-titlebar-close');
+                            if (closeButton) closeButton.click();
+                        }
+                    }
+
+                    // Ctrl+N for new department
+                    if (e.ctrlKey &amp;&amp; e.key === 'n') {
+                        e.preventDefault();
+                        const addButton = document.querySelector('.add-department-btn');
+                        if (addButton) addButton.click();
+                    }
+                });
+            }
+
+            // Enhanced search functionality
+            function enhanceSearch() {
+                const searchInput = document.querySelector('[id$="searchTerm"]');
+                if (searchInput) {
+                    let searchTimeout;
+                    searchInput.addEventListener('input', function() {
+                        clearTimeout(searchTimeout);
+                        const searchContainer = this.closest('.search-container');
+                        searchContainer.classList.add('searching');
+
+                        searchTimeout = setTimeout(() => {
+                            searchContainer.classList.remove('searching');
+                        }, 500);
+                    });
+                }
+            }
+
+            // Add pulse effect to cards on data update
+            function addPulseEffect() {
+                const observer = new MutationObserver(function(mutations) {
+                    mutations.forEach(function(mutation) {
+                        if (mutation.type === 'childList') {
+                            const cards = document.querySelectorAll('.department-card');
+                            cards.forEach(card => {
+                                card.style.animation = 'pulse 0.6s ease-out';
+                                setTimeout(() => {
+                                    card.style.animation = '';
+                                }, 600);
+                            });
+                        }
+                    });
+                });
+
+                const dataViewContent = document.querySelector('.ui-dataview-content');
+                if (dataViewContent) {
+                    observer.observe(dataViewContent, { childList: true, subtree: true });
+                }
+            }
+
+            // Initialize all enhancements
+            setTimeout(() => {
+                enhanceSearch();
+                addPulseEffect();
+            }, 1000);
+        </script>
 
         <ui:include src="departmentForm.xhtml" />
     </ui:define>

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/admin/teams/teamDetails.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/admin/teams/teamDetails.xhtml
@@ -1,0 +1,95 @@
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:ui="http://java.sun.com/jsf/facelets"
+                xmlns:h="http://java.sun.com/jsf/html"
+                xmlns:f="http://java.sun.com/jsf/core"
+                xmlns:p="http://primefaces.org/ui"
+                template="/pages/californiatemplate/template.xhtml">
+
+   <f:metadata>
+      <f:viewParam name="id" value="#{teamDetailsView.teamId}" />
+      <f:event type="preRenderView" listener="#{teamDetailsView.pageLoadInit}" />
+   </f:metadata>
+
+   <ui:define name="title">Team Details</ui:define>
+   <ui:define name="viewname">Teams / #{teamDetailsView.team.name}</ui:define>
+
+   <ui:define name="head">
+      <script type="text/javascript">
+         function kpiPerformanceExtender() { this.cfg.legend = { show: false }; this.cfg.grid = { drawBorder: false, shadow: false }; }
+      </script>
+      <style type="text/css">
+         .summary-card { text-align: left; padding: 1.5rem; background: #fff; border-radius: 8px; height: 100%; }
+         .summary-card .value { font-size: 1.5rem; font-weight: 600; color: #333; }
+         .summary-card .label { font-size: 0.9rem; color: #777; }
+         .chart-card { background: #fff; border-radius: 8px; padding: 1.5rem; text-align: center; height: 100%; position: relative; }
+         .chart-title { font-size: 1rem; font-weight: 600; color: #555; margin-bottom: 1rem; }
+         .chart-center-text { position: absolute; top: 55%; left: 50%; transform: translate(-50%, -50%); font-size: 2rem; font-weight: 700; color: #4CAF50; }
+      </style>
+   </ui:define>
+
+   <ui:define name="content">
+      <h:form id="detailsForm">
+         <p:panel rendered="#{not empty teamDetailsView.team}">
+            <div class="p-grid p-fluid">
+               <!-- Summary Cards Section -->
+               <div class="p-col-12 p-lg-6">
+                  <div class="card summary-card">
+                     <h5>Team Details</h5>
+                     <div class="p-grid p-mt-3">
+                        <div class="p-col-6"><div class="value">#{teamDetailsView.team.name}</div><div class="label">Team Name</div></div>
+                        <div class="p-col-6"><div class="value">#{teamDetailsView.team.teamLead.fullName}</div><div class="label">Team Lead</div></div>
+                        <div class="p-col-6"><div class="value">#{teamDetailsView.team.department.name}</div><div class="label">Department</div></div>
+                        <div class="p-col-6"><div class="value">#{teamDetailsView.teamMembers.size()}</div><div class="label">Total Members</div></div>
+                     </div>
+                  </div>
+               </div>
+
+               <!-- Charts Section -->
+               <div class="p-col-12 p-lg-6">
+                  <div class="p-grid">
+                     <div class="p-col-6">
+                        <div class="card chart-card">
+                           <div class="chart-title">Team KPI Performance</div>
+                           <p:chart type="donut" model="#{teamDetailsView.kpiPerformanceModel}" style="width: 100%; height: 150px;"/>
+                           <div class="chart-center-text">85%</div>
+                        </div>
+                     </div>
+                     <div class="p-col-6">
+                        <div class="card chart-card">
+                           <div class="chart-title">Professional Attributes</div>
+                           <p:chart type="metergauge" model="#{teamDetailsView.professionalRatingsModel}" style="width: 100%; height: 150px;"/>
+                        </div>
+                     </div>
+                  </div>
+               </div>
+
+               <!-- Main Content Section with Tabs -->
+               <div class="p-col-12">
+                  <div class="card">
+                     <p:tabView>
+                        <p:tab title="Goals"><p>Team-specific goals will be listed here.</p></p:tab>
+                        <p:tab title="Members (#{teamDetailsView.teamMembers.size()})">
+                           <p:dataTable var="member" value="#{teamDetailsView.teamMembers}"
+                                        emptyMessage="No members found in this team.">
+                              <p:column headerText="Full Name"><h:outputText value="#{member.fullName}" /></p:column>
+                              <p:column headerText="Designation"><h:outputText value="#{member.designation}" /></p:column>
+                              <p:column headerText="Email"><h:outputText value="#{member.emailAddress}" /></p:column>
+                           </p:dataTable>
+                        </p:tab>
+                        <p:tab title="Activities"><p>Activities assigned to this team will be listed here.</p></p:tab>
+                     </p:tabView>
+                  </div>
+               </div>
+            </div>
+         </p:panel>
+
+         <p:panel rendered="#{empty teamDetailsView.team}">
+            <div class="card" style="text-align: center; padding: 2rem;">
+               <h3>Team Not Found</h3>
+               <p>The team you are looking for does not exist or could not be loaded.</p>
+               <p:button value="Back to Teams List" outcome="/pages/admin/teams/teamsView.xhtml" icon="pi pi-arrow-left"/>
+            </div>
+         </p:panel>
+      </h:form>
+   </ui:define>
+</ui:composition>

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/admin/teams/teamForm.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/admin/teams/teamForm.xhtml
@@ -4,40 +4,42 @@
                 xmlns:f="http://java.sun.com/jsf/core"
                 xmlns:p="http://primefaces.org/ui">
 
-   <p:dialog header="#{teamFormDialog.name}" widgetVar="teamFormDialogWidget"
+   <p:dialog header="Team Details" widgetVar="teamFormDialogWidget"
              modal="true" id="teamFormDialog" resizable="false" draggable="false"
-             width="#{teamFormDialog.width}" height="#{teamFormDialog.height}">
+             width="600">
       <h:form id="teamForm">
-         <p:panelGrid columns="2" styleClass="ui-panelgrid-blank" style="width: 100%;">
-            <p:outputLabel for="name" value="Name:" />
-            <p:inputText id="name" value="#{teamFormDialog.model.name}" required="true" style="width: 100%;"/>
+         <p:panelGrid columns="1" layout="grid" styleClass="ui-panelgrid-blank">
 
-            <p:outputLabel for="department" value="Department:" />
-            <p:selectOneMenu id="department" value="#{teamFormDialog.model.department}"
-                             converter="departmentConverter" required="true" filter="true" filterMatchMode="contains" style="width: 100%;">
-               <f:selectItem itemLabel="Select Department" itemValue="#{null}" noSelectionOption="true"/>
+            <p:outputLabel for="name" value="Team Name"/>
+            <p:inputText id="name" value="#{teamFormDialog.model.name}" required="true"/>
+
+            <p:outputLabel for="department" value="Department"/>
+            <p:selectOneMenu id="department" value="#{teamFormDialog.model.department}" required="true"
+                             converter="departmentConverter" filter="true" filterMatchMode="contains">
+               <f:selectItem itemLabel="-- Select Department --" itemValue="#{null}" />
                <f:selectItems value="#{teamFormDialog.departments}" var="dept"
                               itemLabel="#{dept.name}" itemValue="#{dept}" />
             </p:selectOneMenu>
 
-            <p:outputLabel for="lead" value="Team Lead:" />
+            <p:outputLabel for="lead" value="Team Lead"/>
             <p:selectOneMenu id="lead" value="#{teamFormDialog.model.teamLead}"
-                             converter="userConverter"
-                             filter="true" filterMatchMode="contains" style="width: 100%;">
-               <f:selectItem itemLabel="Select Lead" itemValue="#{null}" noSelectionOption="true"/>
+                             converter="userConverter" filter="true" filterMatchMode="contains">
+               <f:selectItem itemLabel="-- No Lead --" itemValue="#{null}" />
                <f:selectItems value="#{teamFormDialog.users}" var="user"
                               itemLabel="#{user.fullName}" itemValue="#{user}" />
             </p:selectOneMenu>
 
-            <p:outputLabel for="desc" value="Description:" />
-            <p:inputTextarea id="desc" value="#{teamFormDialog.model.description}" rows="4" style="width: 100%;"/>
+            <p:outputLabel for="desc" value="Description"/>
+            <p:inputTextarea id="desc" value="#{teamFormDialog.model.description}" rows="4"/>
 
-            <f:facet name="footer">
-               <p:commandButton value="Save" actionListener="#{teamFormDialog.save()}"
-                                update=":teamsForm :growl" oncomplete="if(!args.validationFailed) PF('teamFormDialogWidget').hide()" />
-               <p:commandButton value="Cancel" oncomplete="PF('teamFormDialogWidget').hide()" immediate="true" process="@this"/>
-            </f:facet>
          </p:panelGrid>
+         <div class="p-d-flex p-jc-end p-mt-3">
+            <p:commandButton value="Save" actionListener="#{teamFormDialog.save()}"
+                             update=":teamsForm"
+                             oncomplete="if(args &amp;&amp; args.saved){ PF('teamFormDialogWidget').hide(); }"/>
+            <p:commandButton value="Cancel" oncomplete="PF('teamFormDialogWidget').hide()"
+                             immediate="true" process="@this" styleClass="ui-button-secondary p-ml-2"/>
+         </div>
       </h:form>
    </p:dialog>
 </ui:composition>

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/admin/teams/teamsView.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/admin/teams/teamsView.xhtml
@@ -6,65 +6,123 @@
                 template="/pages/californiatemplate/template.xhtml">
 
     <ui:define name="title">Manage Teams</ui:define>
+    <ui:define name="viewname">Teams</ui:define>
 
     <ui:define name="content">
+        <style type="text/css">
+            .team-grid-container .ui-dataview-content {
+                border: none;
+                background: transparent;
+                padding: 0 !important;
+            }
+            .team-card {
+                background: #ffffff;
+                border-radius: 8px;
+                box-shadow: 0 4px 6px rgba(0,0,0,0.05);
+                transition: all 0.2s ease-in-out;
+                margin-bottom: 1.5rem;
+                cursor: pointer; /* show clickable */
+                display: flex;
+                flex-direction: column;
+                height: 100%;
+            }
+            .team-card:hover {
+                transform: translateY(-4px);
+                box-shadow: 0 8px 16px rgba(0,0,0,0.1);
+            }
+            .card-actions {
+                border-top: 1px solid #e9ecef;
+                padding: 0.75rem 1.25rem;
+                display: flex;
+                justify-content: flex-end;
+                gap: 0.5rem;
+            }
+
+            /* reset PrimeFaces button styles */
+            .team-card.p-button {
+                all: unset;
+                display: block;
+                cursor: pointer;
+                border-radius: 8px;
+            }
+            .team-card:hover {
+                transform: translateY(-4px);
+                box-shadow: 0 8px 16px rgba(0,0,0,0.1);
+            }
+            .card-content {
+                padding: 1.25rem;
+                flex-grow: 1;
+            }
+            .card-header-text {
+                font-size: 1.1rem;
+                font-weight: 600;
+                color: #343a40;
+                margin-bottom: 0.5rem;
+            }
+            .card-meta-text {
+                font-size: 0.875rem;
+                color: #6c757d;
+                margin-bottom: 0.5rem;
+            }
+        </style>
+
         <div class="card">
             <h:form id="teamsForm">
-                <p:dataTable id="teamsTable" widgetVar="teamsTableWidget" var="team" value="#{teamsView.dataModels}" lazy="true"
-                             rowKey="#{team.id}"
-                             paginator="true" rows="#{teamsView.maximumresultsPerpage}"
-                             paginatorPosition="bottom"
-                             emptyMessage="No teams found.">
+                <p:growl id="growl" showDetail="true" />
+                <div class="p-d-flex p-jc-between p-ai-center p-mb-3">
+                    <h:panelGroup>
+                        <span style="font-size: 1.5rem; font-weight: 600;">Teams List</span>
+                        <p class="text-secondary">Manage all teams across departments</p>
+                    </h:panelGroup>
+                    <div class="p-d-flex p-ai-center">
+                         <span class="ui-input-icon-left p-mr-2">
+                            <i class="pi pi-search" />
+                            <p:inputText value="#{teamsView.searchTerm}" placeholder="Search...">
+                                <p:ajax event="keyup" update="teamsDataView" />
+                            </p:inputText>
+                        </span>
+                        <p:commandButton value="Add Team" icon="pi pi-plus" process="@this"
+                                         actionListener="#{teamFormDialog.resetModal()}"
+                                         oncomplete="PF('teamFormDialogWidget').show()"
+                                         update=":teamForm"/>
+                    </div>
+                </div>
 
-                    <f:facet name="header">
-                        <div class="ui-g">
-                            <div class="ui-g-6" style="text-align: left">
-                                Manage Teams
+                <p:dataView id="teamsDataView" var="team" value="#{teamsView}" lazy="true"
+                            layout="grid"
+                            paginator="true" rows="12" paginatorPosition="bottom"
+                            emptyMessage="No teams found." styleClass="team-grid-container">
+
+                    <p:dataViewGridItem>
+                        <div class="team-card" onclick="window.location='#{request.contextPath}/pages/admin/teams/teamDetails.xhtml?id=#{team.id}'">
+                            <div class="card-content">
+                                <div class="card-header-text">#{team.name}</div>
+                                <div class="card-meta-text">Department: #{team.department.name}</div>
+                                <div class="card-meta-text">Lead: #{team.teamLead != null ? team.teamLead.fullName : 'N/A'}</div>
                             </div>
-                            <div class="ui-g-6" style="text-align: right">
-                                <p:commandButton value="Add Team" icon="pi pi-plus"
-                                                 actionListener="#{teamsView.teamFormDialog.resetModal()}"
-                                                 oncomplete="PF('teamFormDialogWidget').show()"
-                                                 update=":teamFormDialog"/>
+                            <div class="card-actions">
+                                <div>
+                                    <p:commandButton icon="pi pi-pencil" title="Edit" styleClass="ui-button-rounded ui-button-info"
+                                                     actionListener="#{teamFormDialog.setModel(team)}"
+                                                     oncomplete="PF('teamFormDialogWidget').show()"
+                                                     update=":teamForm" />
+                                    <p:commandButton icon="pi pi-trash" title="Delete" styleClass="ui-button-rounded ui-button-danger"
+                                                     actionListener="#{teamsView.deleteTeam(team)}"
+                                                     update="@form">
+                                        <p:confirm header="Confirmation"
+                                                   message="Are you sure you want to delete this team?"
+                                                   icon="pi pi-exclamation-triangle" />
+                                    </p:commandButton>
+                                </div>
                             </div>
                         </div>
-                    </f:facet>
+                    </p:dataViewGridItem>
+                </p:dataView>
 
-                    <p:column headerText="Name" sortBy="#{team.name}">
-                        <h:outputText value="#{team.name}" />
-                    </p:column>
-
-                    <p:column headerText="Department" sortBy="#{team.department.name}">
-                        <h:outputText value="#{team.department.name}" />
-                    </p:column>
-
-                    <p:column headerText="Team Lead" sortBy="#{team.teamLead.fullName}">
-                        <h:outputText value="#{team.teamLead.fullName}" />
-                    </p:column>
-
-                    <p:column headerText="Actions" style="width:100px;text-align: center">
-                        <p:commandButton icon="pi pi-pencil" title="Edit"
-                                         actionListener="#{teamsView.teamFormDialog.setModel(team)}"
-                                         oncomplete="PF('teamFormDialogWidget').show()"
-                                         update=":teamFormDialog">
-                        </p:commandButton>
-
-                        <p:commandButton icon="pi pi-trash" title="Delete"
-                                         actionListener="#{teamsView.deleteTeam(team)}"
-                                         update="@form" >
-                            <p:confirm header="Confirmation" message="Are you sure you want to delete this team?" icon="pi pi-exclamation-triangle" />
-                        </p:commandButton>
-                    </p:column>
-                </p:dataTable>
-                <!-- FIX: Add the required confirmation dialog -->
-                <p:confirmDialog global="true" showEffect="fade" hideEffect="fade" responsive="true" width="350">
-                    <p:commandButton value="Yes" type="button" styleClass="ui-confirmdialog-yes" icon="pi pi-check" />
-                    <p:commandButton value="No" type="button" styleClass="ui-confirmdialog-no ui-button-secondary" icon="pi pi-times" />
-                </p:confirmDialog>
+                <p:confirmDialog global="true" showEffect="fade" hideEffect="fade"/>
             </h:form>
         </div>
 
-        <!-- Include the dialog form -->
         <ui:include src="teamForm.xhtml" />
     </ui:define>
 </ui:composition>


### PR DESCRIPTION
feat(teams): Refactored complete Teams management module

This commit delivers the full end-to-end functionality for managing Teams, mirroring the architecture and UI/UX of the Departments module for consistency.

**Backend:**
  The `Team` model is established with relationships to `Department` and `EmployeeUser`.
  `TeamService` is implemented with full CRUD operations and business logic, including validation for unique team names within a department.
  `EmployeeUserService` is extended with a method to fetch all members assigned to a specific team.

**Teams List View (`teamsView.xhtml`):**
  A responsive, card-based grid layout using `p:dataView` displays all teams.
  The entire card is now clickable using JavaScript (`onclick`) for a smoother user experience, navigating to the team's details page.
  Live AJAX search functionality is included to filter teams in real-time.
  Edit and Delete actions are available on each card.

**Team Details Page (`teamDetails.xhtml`):**
  A new dashboard page provides a detailed overview of a single team.
  Displays summary information: Team Name, Lead, Department, and total member count.
  Includes dummy data charts for "KPI Performance" and "Professional Attributes".
  The "Members" tab is populated with a data table showing all employees assigned to the team.
