### PR TITLE
Add view for subcategories of professional attributes

### DIFF
--- a/backend/kpi-tracker-models/src/main/java/org/pahappa/systems/kpiTracker/models/ProfessionalAttrGrade.java
+++ b/backend/kpi-tracker-models/src/main/java/org/pahappa/systems/kpiTracker/models/ProfessionalAttrGrade.java
@@ -1,0 +1,57 @@
+package org.pahappa.systems.kpiTracker.models;
+
+import org.sers.webutils.model.BaseEntity;
+import org.sers.webutils.model.security.User;
+
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "professional_attr_grade")
+public class ProfessionalAttrGrade extends BaseEntity {
+    private User evaluatorUser;
+    private User evaluatedUser;
+    private ProfessionalAttrSubcategory professionalAttrSubcategory;
+    private int value;
+
+    public int getValue() {
+        return value;
+    }
+
+    public void setValue(int value) {
+        this.value = value;
+    }
+
+    @OneToOne
+    @JoinColumn(name="professional_attr_subcategory", nullable=false)
+    public ProfessionalAttrSubcategory getProfessionalAttrSubcategory() {
+        return professionalAttrSubcategory;
+    }
+
+    public void setProfessionalAttrSubcategory(ProfessionalAttrSubcategory professionalAttrSubcategory) {
+        this.professionalAttrSubcategory = professionalAttrSubcategory;
+    }
+
+    @OneToOne
+    @JoinColumn(name = "evaluator_user", nullable = false)
+    public User getEvaluatorUser() {
+        return evaluatorUser;
+    }
+
+    public void setEvaluatorUser(User evaluatorUser) {
+        this.evaluatorUser = evaluatorUser;
+    }
+
+    @OneToOne
+    @JoinColumn(name = "evaluated_user", nullable = false)
+    public User getEvaluatedUser() {
+        return evaluatedUser;
+    }
+
+    public void setEvaluatedUser(User evaluatedUser) {
+        this.evaluatedUser = evaluatedUser;
+    }
+
+}

--- a/backend/kpi-tracker-models/src/main/java/org/pahappa/systems/kpiTracker/models/ProfessionalAttrSubcategory.java
+++ b/backend/kpi-tracker-models/src/main/java/org/pahappa/systems/kpiTracker/models/ProfessionalAttrSubcategory.java
@@ -12,28 +12,6 @@ public class ProfessionalAttrSubcategory extends BaseEntity {
     private ProfessionalAttrCategory professionalAttrCategory;
     private int maximumValue;
     private int contributionWeight;
-    private User evaluatorUser;
-    private User evaluatedUser;
-
-    @OneToOne
-    @JoinColumn(name = "evaluator_user", nullable = false)
-    public User getEvaluatorUser() {
-        return evaluatorUser;
-    }
-
-    public void setEvaluatorUser(User evaluatorUser) {
-        this.evaluatorUser = evaluatorUser;
-    }
-
-    @OneToOne
-    @JoinColumn(name = "evaluated_user", nullable = false)
-    public User getEvaluatedUser() {
-        return evaluatedUser;
-    }
-
-    public void setEvaluatedUser(User evaluatedUser) {
-        this.evaluatedUser = evaluatedUser;
-    }
 
     @Column(name = "maximum_value", nullable = false)
     public int getMaximumValue() {

--- a/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/ProfessionalAttrGradeService.java
+++ b/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/ProfessionalAttrGradeService.java
@@ -1,0 +1,7 @@
+package org.pahappa.systems.kpiTracker.core.services;
+
+import org.pahappa.systems.kpiTracker.core.services.base.GenericService;
+import org.pahappa.systems.kpiTracker.models.ProfessionalAttrGrade;
+
+public interface ProfessionalAttrGradeService extends GenericService<ProfessionalAttrGrade> {
+}

--- a/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/ProfessionalAttrSubcategoryService.java
+++ b/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/ProfessionalAttrSubcategoryService.java
@@ -1,0 +1,12 @@
+package org.pahappa.systems.kpiTracker.core.services;
+
+import org.pahappa.systems.kpiTracker.core.services.base.GenericService;
+import org.pahappa.systems.kpiTracker.models.ProfessionalAttrCategory;
+import org.pahappa.systems.kpiTracker.models.ProfessionalAttrSubcategory;
+
+import java.util.List;
+
+public interface ProfessionalAttrSubcategoryService extends GenericService<ProfessionalAttrSubcategory> {
+
+    List<ProfessionalAttrSubcategory> getSubcategoriesForAttribute(ProfessionalAttrCategory attribute);
+}

--- a/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/impl/ProfessionalAttrGradeServiceImpl.java
+++ b/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/impl/ProfessionalAttrGradeServiceImpl.java
@@ -1,0 +1,22 @@
+package org.pahappa.systems.kpiTracker.core.services.impl;
+
+import org.pahappa.systems.kpiTracker.core.services.impl.base.GenericServiceImpl;
+import org.pahappa.systems.kpiTracker.models.ProfessionalAttrGrade;
+import org.pahappa.systems.kpiTracker.utils.Validate;
+import org.sers.webutils.model.exception.OperationFailedException;
+import org.sers.webutils.model.exception.ValidationFailedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service("professionalAttrGradeService")
+@Transactional
+public class ProfessionalAttrGradeServiceImpl extends GenericServiceImpl<ProfessionalAttrGrade> {
+    public boolean isDeletable(ProfessionalAttrGrade professionalAttrGrade) throws OperationFailedException {
+        return true;
+    }
+
+    public ProfessionalAttrGrade saveInstance(ProfessionalAttrGrade professionalAttrGrade) throws ValidationFailedException, OperationFailedException {
+        Validate.notNull(professionalAttrGrade, "Grade cannot be null");
+        return super.save(professionalAttrGrade);
+    }
+}

--- a/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/impl/ProfessionalAttrSubcategoryServiceImpl.java
+++ b/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/impl/ProfessionalAttrSubcategoryServiceImpl.java
@@ -1,19 +1,35 @@
 package org.pahappa.systems.kpiTracker.core.services.impl;
 
+import com.googlecode.genericdao.search.Search;
+import org.pahappa.systems.kpiTracker.core.services.ProfessionalAttrSubcategoryService;
 import org.pahappa.systems.kpiTracker.core.services.impl.base.GenericServiceImpl;
+import org.pahappa.systems.kpiTracker.models.ProfessionalAttrCategory;
 import org.pahappa.systems.kpiTracker.models.ProfessionalAttrSubcategory;
 import org.pahappa.systems.kpiTracker.utils.Validate;
+import org.sers.webutils.model.RecordStatus;
 import org.sers.webutils.model.exception.OperationFailedException;
 import org.sers.webutils.model.exception.ValidationFailedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-public class ProfessionalAttrSubcategoryServiceImpl extends GenericServiceImpl<ProfessionalAttrSubcategory> {
+import java.util.List;
+
+@Service("professionalAttrSubcategoryService")
+@Transactional
+public class ProfessionalAttrSubcategoryServiceImpl extends GenericServiceImpl<ProfessionalAttrSubcategory> implements ProfessionalAttrSubcategoryService {
     public boolean isDeletable(ProfessionalAttrSubcategory professionalAttrSubcategory) throws OperationFailedException {
         return true;
     }
 
     public ProfessionalAttrSubcategory saveInstance(ProfessionalAttrSubcategory professionalAttrSubcategory) throws ValidationFailedException, OperationFailedException {
         Validate.notNull(professionalAttrSubcategory, "Subcategory cannot be null");
-
         return super.save(professionalAttrSubcategory);
+    }
+
+    public List<ProfessionalAttrSubcategory> getSubcategoriesForAttribute(ProfessionalAttrCategory attribute) {
+        Search search = new Search();
+        search.addFilterEqual("professionalAttrCategory", attribute); // Assumes field name is 'professionalAttrCategory'
+        search.addFilterEqual("recordStatus", RecordStatus.ACTIVE);
+        return super.search(search);
     }
 }

--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/dialogs/ProfessionalAttrFormDialog.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/dialogs/ProfessionalAttrFormDialog.java
@@ -6,30 +6,37 @@ import org.pahappa.systems.kpiTracker.core.services.ProfessionalAttrCategoryServ
 import org.pahappa.systems.kpiTracker.models.GoalCycle;
 import org.pahappa.systems.kpiTracker.models.ProfessionalAttrCategory;
 import org.sers.webutils.model.exception.OperationFailedException;
+import org.sers.webutils.model.security.User;
+import org.sers.webutils.server.core.service.UserService;
 import org.sers.webutils.server.core.utils.ApplicationContextProvider;
 
 import javax.annotation.PostConstruct;
 import javax.faces.application.FacesMessage;
 import javax.faces.bean.ManagedBean;
-import javax.faces.bean.ViewScoped;
+import javax.faces.bean.SessionScoped;
 import javax.faces.context.FacesContext;
 import java.io.Serializable;
+import java.util.List;
 
 @ManagedBean(name = "professionalAttrFormDialog")
-@ViewScoped
+@SessionScoped
 @Getter
 @Setter
 public class ProfessionalAttrFormDialog implements Serializable {
 
     private static final long serialVersionUID = 1L;
     private ProfessionalAttrCategory model;
-    private transient ProfessionalAttrCategoryService professionalAttrCategoryService;
-    private String updateTarget; // This will hold the ID of the component to refresh after saving
+    private ProfessionalAttrCategoryService professionalAttrCategoryService;
+    private String updateTarget;
+    private List<User> allUsers;
+    private UserService userService;
 
     @PostConstruct
-    public void init() {
+    public void init() throws OperationFailedException {
         this.professionalAttrCategoryService = ApplicationContextProvider.getBean(ProfessionalAttrCategoryService.class);
         this.model = new ProfessionalAttrCategory();
+        this.userService = ApplicationContextProvider.getBean(UserService.class);
+        this.allUsers = this.userService.getUsers();
     }
 
     /**
@@ -37,7 +44,7 @@ public class ProfessionalAttrFormDialog implements Serializable {
      * This is called by the "Add" button.
      * @param goalCycle The cycle to which the new attribute will belong.
      */
-    public void prepareNew(GoalCycle goalCycle) {
+    public void prepareNewProfessionalAttr(GoalCycle goalCycle) {
         this.model = new ProfessionalAttrCategory();
         this.model.setGoalCycle(goalCycle);
     }

--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/dialogs/ProfessionalAttrSubcategoryFormDialog.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/dialogs/ProfessionalAttrSubcategoryFormDialog.java
@@ -1,0 +1,59 @@
+package org.pahappa.systems.kpiTracker.views.dialogs;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.pahappa.systems.kpiTracker.core.services.ProfessionalAttrSubcategoryService;
+import org.pahappa.systems.kpiTracker.models.ProfessionalAttrCategory;
+import org.pahappa.systems.kpiTracker.models.ProfessionalAttrSubcategory;
+import org.sers.webutils.model.exception.OperationFailedException;
+import org.sers.webutils.server.core.utils.ApplicationContextProvider;
+
+import javax.annotation.PostConstruct;
+import javax.faces.application.FacesMessage;
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.SessionScoped;
+import javax.faces.context.FacesContext;
+import java.io.Serializable;
+
+@ManagedBean(name = "professionalAttrSubcategoryFormDialog")
+@SessionScoped
+@Getter
+@Setter
+public class ProfessionalAttrSubcategoryFormDialog implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+    private ProfessionalAttrSubcategory model;
+    private ProfessionalAttrSubcategoryService subcategoryService;
+    private String updateTarget;
+
+    @PostConstruct
+    public void init() throws OperationFailedException {
+        this.subcategoryService = ApplicationContextProvider.getBean(ProfessionalAttrSubcategoryService.class);
+        this.model = new ProfessionalAttrSubcategory();
+    }
+
+    public void prepareNewProfessionalAttr(ProfessionalAttrCategory parentAttribute) {
+        this.model = new ProfessionalAttrSubcategory();
+        this.model.setProfessionalAttrCategory(parentAttribute);
+    }
+
+    public void save() {
+        try {
+            if (this.model.getDescription() == null || this.model.getDescription().trim().isEmpty()) {
+                throw new RuntimeException("Description is required.");
+            }
+            if (this.model.getMaximumValue() <= 0) {
+                throw new RuntimeException("Maximum Value must be a positive number.");
+            }
+
+            subcategoryService.saveInstance(this.model);
+
+            FacesMessage message = new FacesMessage(FacesMessage.SEVERITY_INFO, "Success", "Sub-Category saved successfully.");
+            FacesContext.getCurrentInstance().addMessage(null, message);
+
+        } catch (Exception e) {
+            FacesMessage message = new FacesMessage(FacesMessage.SEVERITY_ERROR, "Error", e.getMessage());
+            FacesContext.getCurrentInstance().addMessage(null, message);
+        }
+    }
+}

--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/goals/GoalCycleView.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/goals/GoalCycleView.java
@@ -94,7 +94,7 @@ public class GoalCycleView implements Serializable {
      */
     public void prepareNewProfessionalAttribute() {
         if (selectedCycle != null) {
-            professionalAttrFormDialog.prepareNew(this.selectedCycle);
+            professionalAttrFormDialog.prepareNewProfessionalAttr(this.selectedCycle);
             professionalAttrFormDialog.setUpdateTarget(":cycleDashboardForm:professionalAttrsTable");
         }
     }

--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/professionalAttrs/ProfessionalAttrSubcategoryView.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/professionalAttrs/ProfessionalAttrSubcategoryView.java
@@ -1,0 +1,77 @@
+package org.pahappa.systems.kpiTracker.views.professionalAttrs;
+import lombok.Getter;
+import lombok.Setter;
+import org.pahappa.systems.kpiTracker.core.services.ProfessionalAttrCategoryService;
+import org.pahappa.systems.kpiTracker.core.services.ProfessionalAttrSubcategoryService;
+import org.pahappa.systems.kpiTracker.models.ProfessionalAttrCategory;
+import org.pahappa.systems.kpiTracker.models.ProfessionalAttrSubcategory;
+import org.pahappa.systems.kpiTracker.views.dialogs.ProfessionalAttrSubcategoryFormDialog;
+import org.sers.webutils.client.views.presenters.ViewPath;
+import org.sers.webutils.server.core.utils.ApplicationContextProvider;
+
+import javax.annotation.PostConstruct;
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.ManagedProperty;
+import javax.faces.bean.ViewScoped;
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
+
+@ManagedBean(name = "professionalAttrSubcategoryView")
+@ViewScoped
+@Getter
+@Setter
+@ViewPath(path = "/pages/admin/goals/professionalAttrDetailView.xhtml")
+public class ProfessionalAttrSubcategoryView implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private ProfessionalAttrCategoryService professionalAttrCategoryService;
+    private ProfessionalAttrSubcategoryService professionalAttrSubcategoryService;
+
+    private String attrId;
+    private ProfessionalAttrCategory selectedAttribute;
+
+    private List<ProfessionalAttrSubcategory> subCategories;
+
+    @ManagedProperty(value = "#{professionalAttrSubcategoryFormDialog}")
+    private ProfessionalAttrSubcategoryFormDialog subcategoryFormDialog;
+
+    @PostConstruct
+    public void init() {
+        this.professionalAttrSubcategoryService = ApplicationContextProvider.getBean(ProfessionalAttrSubcategoryService.class);
+        this.professionalAttrCategoryService = ApplicationContextProvider.getBean(ProfessionalAttrCategoryService.class);
+        this.subCategories = Collections.emptyList();
+    }
+
+    /**
+     * This method is called by the <f:viewAction> on the page.
+     * It uses the attrId passed in the URL to load the correct attribute.
+     */
+    public void loadAttribute() {
+        if (attrId != null) {
+            this.selectedAttribute = professionalAttrCategoryService.getInstanceByID(attrId);
+            if (this.selectedAttribute != null) {
+                // Future logic to load sub-categories will go here.
+                // e.g., this.subCategories = subCategoryService.getSubCategoriesFor(this.selectedAttribute);
+            }
+        }
+    }
+
+    public void loadData() {
+        if (attrId != null) {
+            this.selectedAttribute = professionalAttrCategoryService.getInstanceByID(attrId);
+            if (this.selectedAttribute != null) {
+                // Now, load the sub-categories for the selected attribute
+                this.subCategories = professionalAttrSubcategoryService.getSubcategoriesForAttribute(this.selectedAttribute);
+            }
+        }
+    }
+
+    public void prepareNewSubcategory() {
+        if (this.selectedAttribute != null) {
+            subcategoryFormDialog.prepareNewProfessionalAttr(this.selectedAttribute);
+            subcategoryFormDialog.setUpdateTarget(":subcategoryForm:subcategoriesTable");
+        }
+    }
+}

--- a/frontend/kpi-tracker-web/src/main/resources/hibernate.cfg.xml
+++ b/frontend/kpi-tracker-web/src/main/resources/hibernate.cfg.xml
@@ -58,6 +58,7 @@
 		<mapping class="org.pahappa.systems.kpiTracker.models.security.EmployeeUser" />
 		<mapping class="org.pahappa.systems.kpiTracker.models.Department" />
 		<mapping class="org.pahappa.systems.kpiTracker.models.Team" />
+		<mapping class="org.pahappa.systems.kpiTracker.models.ProfessionalAttrGrade" />
 
 	</session-factory>
 </hibernate-configuration>

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/admin/goals/goalCycleView.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/admin/goals/goalCycleView.xhtml
@@ -125,8 +125,12 @@
                                 <h:outputText value="#{profAttr.contributionWeight}%"/>
                             </p:column>
 
-                            <p:column headerText="Actions" style="width:100px;text-align: center">
-                                <p:commandButton icon="pi pi-pencil" title="Edit" styleClass="ui-button-warning"
+                            <p:column headerText="Actions" style="width:150px; text-align: center">
+                                <p:button icon="pi pi-search" title="View Details" styleClass="ui-button-secondary ui-button-outlined"
+                                          outcome="/pages/admin/goals/professionalAttrDetailView.xhtml">
+                                    <f:param name="attrId" value="#{profAttr.id}"/>
+                                </p:button>
+                                <p:commandButton icon="pi pi-pencil" title="Edit" styleClass="ui-button-warning" style="margin-left: 5px;"
                                                  actionListener="#{goalCycleView.prepareEditProfessionalAttribute(profAttr)}"
                                                  oncomplete="PF('professionalAttrDialogWidget').show()"
                                                  update=":professionalAttrForm"/>

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/admin/goals/professionalAttrDetailView.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/admin/goals/professionalAttrDetailView.xhtml
@@ -1,0 +1,99 @@
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:h="http://java.sun.com/jsf/html"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns:ui="http://java.sun.com/jsf/facelets"
+                xmlns:p="http://primefaces.org/ui"
+                template="/pages/californiatemplate/template.xhtml">
+
+   <f:metadata>
+      <f:viewParam name="attrId" value="#{professionalAttrSubcategoryView.attrId}"/>
+      <f:viewAction action="#{professionalAttrSubcategoryView.loadData}"/>
+   </f:metadata>
+
+   <ui:define name="title">
+      #{professionalAttrSubcategoryView.selectedAttribute ne null ? professionalAttrSubcategoryView.selectedAttribute.title : 'Attribute Details'}
+   </ui:define>
+
+   <ui:define name="content">
+      <div class="card">
+         <h:form id="subcategoryForm">
+            <!-- Main Details Panel for the Parent Attribute -->
+            <p:panel rendered="#{professionalAttrSubcategoryView.selectedAttribute != null}">
+               <f:facet name="header">
+                  <div class="p-d-flex p-jc-between p-ai-center">
+                     <h:outputText value="Details for: #{professionalAttrSubcategoryView.selectedAttribute.title}" style="font-size: 1.5rem; font-weight: bold;"/>
+                     <!-- Button to go back to the previous dashboard, passing the cycleId -->
+                     <p:button outcome="/pages/admin/goals/goalCycleView.xhtml" value="Back to Dashboard" icon="pi pi-arrow-left">
+                        <f:param name="cycleId" value="#{professionalAttrSubcategoryView.selectedAttribute.goalCycle.id}"/>
+                     </p:button>
+                  </div>
+               </f:facet>
+
+               <p:panelGrid columns="2" layout="grid" styleClass="ui-panelgrid-blank" columnClasses="p-col-3, p-col-9">
+                  <h:outputText value="Title:" style="font-weight: bold;"/>
+                  <h:outputText value="#{professionalAttrSubcategoryView.selectedAttribute.title}"/>
+
+                  <h:outputText value="Description:" style="font-weight: bold;"/>
+                  <h:outputText value="#{professionalAttrSubcategoryView.selectedAttribute.description}"/>
+
+                  <h:outputText value="Contribution Weight:" style="font-weight: bold;"/>
+                  <h:outputText value="#{professionalAttrSubcategoryView.selectedAttribute.contributionWeight}%"/>
+
+                  <h:outputText value="Belongs to Cycle:" style="font-weight: bold;"/>
+                  <h:outputText value="#{professionalAttrSubcategoryView.selectedAttribute.goalCycle.title}"/>
+               </p:panelGrid>
+            </p:panel>
+
+            <!-- Sub-Categories Panel -->
+            <p:panel style="margin-top: 20px;">
+               <f:facet name="header">
+                  <div class="p-d-flex p-jc-between p-ai-center">
+                     <h4>Sub-Categories</h4>
+                     <p:commandButton value="Add Sub-Category" icon="pi pi-plus"
+                                      actionListener="#{professionalAttrSubcategoryView.prepareNewSubcategory()}"
+                                      oncomplete="PF('subcategoryDialogWidget').show()"
+                                      update=":subcategoryDialogForm" process="@this"/>
+                  </div>
+               </f:facet>
+
+               <p:dataTable id="subcategoriesTable" var="subcat" value="#{professionalAttrSubcategoryView.subCategories}"
+                            emptyMessage="No sub-categories have been created for this attribute."
+                            rows="10" paginator="true" paginatorPosition="bottom"
+                            paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                            rowsPerPageTemplate="5,10,15,20">
+
+                  <p:column headerText="Description" sortBy="#{subcat.description}">
+                     <h:outputText value="#{subcat.description}" />
+                  </p:column>
+
+                  <p:column headerText="Max Value" style="width: 120px; text-align: center;" sortBy="#{subcat.maximumValue}">
+                     <h:outputText value="#{subcat.maximumValue}" />
+                  </p:column>
+
+                  <p:column headerText="Weight (%)" style="width: 120px; text-align: center;" sortBy="#{subcat.contributionWeight}">
+                     <h:outputText value="#{subcat.contributionWeight}%" />
+                  </p:column>
+
+                  <p:column headerText="Actions" style="width:100px; text-align: center">
+                     <p:commandButton icon="pi pi-pencil" title="Edit" styleClass="ui-button-warning"
+                                      disabled="true"/>
+                  </p:column>
+               </p:dataTable>
+
+            </p:panel>
+
+            <!-- Fallback panel if the attribute could not be found -->
+            <p:panel rendered="#{professionalAttrSubcategoryView.selectedAttribute == null}">
+               <div class="p-text-center">
+                  <h3>Professional Attribute Not Found</h3>
+                  <p>The requested attribute could not be found.</p>
+                  <p:button outcome="/pages/admin/goals/goalsView.xhtml" value="Back to Cycles" icon="pi pi-arrow-left"/>
+               </div>
+            </p:panel>
+         </h:form>
+      </div>
+
+      <!-- Include the new sub-category dialog -->
+      <ui:include src="professionalAttrSubcategoryForm.xhtml"/>
+   </ui:define>
+</ui:composition>

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/admin/goals/professionalAttrSubcategoryForm.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/admin/goals/professionalAttrSubcategoryForm.xhtml
@@ -1,0 +1,53 @@
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:h="http://java.sun.com/jsf/html"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns:ui="http://java.sun.com/jsf/facelets"
+                xmlns:p="http://primefaces.org/ui">
+
+    <p:dialog
+            header="#{empty professionalAttrSubcategoryFormDialog.model.id ? 'New Sub-Category' : 'Edit Sub-Category'}"
+            widgetVar="subcategoryDialogWidget"
+            modal="true"
+            resizable="false"
+            closable="true"
+            closeOnEscape="true"
+            style="min-width: 500px;">
+
+        <h:form id="subcategoryDialogForm">
+            <p:messages id="dialogMessages" showDetail="true" closable="true">
+                <p:autoUpdate/>
+            </p:messages>
+
+            <div class="p-fluid formgrid grid" style="margin-top: 10px;">
+
+                <div class="field col-12">
+                    <p:outputLabel for="description" value="Description"/>
+                    <p:inputTextarea id="description" value="#{professionalAttrSubcategoryFormDialog.model.description}"
+                                     rows="4" required="true" requiredMessage="Description is required."/>
+                </div>
+
+                <div class="field col-12 md:col-6">
+                    <p:outputLabel for="maxValue" value="Maximum Value"/>
+                    <p:inputNumber id="maxValue" value="#{professionalAttrSubcategoryFormDialog.model.maximumValue}"
+                                   required="true" requiredMessage="Maximum Value is required." minValue="1"/>
+                </div>
+
+                <div class="field col-12 md:col-6">
+                    <p:outputLabel for="weight" value="Contribution Weight (%)"/>
+                    <p:inputNumber id="weight" value="#{professionalAttrSubcategoryFormDialog.model.contributionWeight}"
+                                   minValue="0" maxValue="100" symbol=" %" symbolPosition="s"/>
+                </div>
+            </div>
+
+            <div class="p-d-flex p-jc-end" style="margin-top: 20px;">
+                <p:commandButton value="Cancel" type="button" styleClass="ui-button-secondary"
+                                 onclick="PF('subcategoryDialogWidget').hide()"/>
+
+                <p:commandButton value="Save" icon="pi pi-check" style="margin-left: 5px;"
+                                 actionListener="#{professionalAttrSubcategoryFormDialog.save}"
+                                 update="#{professionalAttrSubcategoryFormDialog.updateTarget} @form"
+                                 oncomplete="if (args &amp;&amp; !args.validationFailed &amp;&amp; !facesContext.isValidationFailed()) { PF('subcategoryDialogWidget').hide(); }"/>
+            </div>
+        </h:form>
+    </p:dialog>
+</ui:composition>


### PR DESCRIPTION
#### Description
=> Add navigable page on which the admin can view the related subcategories of a single professional attributes category
#### Type of change
=> Please select the relevant option
- [ ] Bug fix (non-breaking change which fixes an issue)
- [*] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Others (cosmetics, styling, improvements)
- [ ] This change requires a documentation update
#### How Has This Been Tested?
=> Please select the relevant option
- [ ] Unit
- [ ] Integration
- [ ] End-to-end
#### How can this be Tested?
=> Include the steps needed to test this PR
#### Any background context you want to add
