### PR TITLE
Search area on users view not refreshing per prompt

### DIFF
--- a/frontend/kpi-tracker-web/src/main/webapp/pages/users/UsersView.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/users/UsersView.xhtml
@@ -71,7 +71,7 @@
                                 <div class="p-text-bold p-text-xl">#{usersView.total}</div>
                             </div>
                             <div class="p-d-flex p-ai-center p-jc-center bg-blue-100" style="width:2.5rem;height:2.5rem; border-radius: 50%;">
-                                <i class="pi pi-users p-text-xl text-blue-500"></i>
+                                <i class="pi pi-users p-text-xl text-blue-500"> </i>
                             </div>
                         </div>
                     </div>
@@ -84,7 +84,7 @@
                                 <div class="p-text-bold p-text-xl">#{usersView.noMale}</div>
                             </div>
                             <div class="p-d-flex p-ai-center p-jc-center bg-green-100" style="width:2.5rem;height:2.5rem; border-radius: 50%;">
-                                <i class="pi pi-user p-text-xl text-green-500"></i>
+                                <i class="pi pi-user p-text-xl text-green-500"> </i>
                             </div>
                         </div>
                     </div>
@@ -97,7 +97,7 @@
                                 <div class="p-text-bold p-text-xl">#{usersView.noFemale}</div>
                             </div>
                             <div class="p-d-flex p-ai-center p-jc-center bg-pink-100" style="width:2.5rem;height:2.5rem; border-radius: 50%;">
-                                <i class="pi pi-user p-text-xl text-pink-500"></i>
+                                <i class="pi pi-user p-text-xl text-pink-500"> </i>
                             </div>
                         </div>
                     </div>
@@ -110,7 +110,7 @@
                                 <div class="p-text-bold p-text-xl">#{usersView.noUnknown}</div>
                             </div>
                             <div class="p-d-flex p-ai-center p-jc-center bg-gray-100" style="width:2.5rem;height:2.5rem; border-radius: 50%;">
-                                <i class="pi pi-question-circle p-text-xl text-gray-500"></i>
+                                <i class="pi pi-question-circle p-text-xl text-gray-500"> </i>
                             </div>
                         </div>
                     </div>
@@ -119,6 +119,61 @@
 
             <!-- Main Table Card -->
             <div class="card">
+                <p:toolbar style="margin-bottom: 1rem;">
+                    <p:toolbarGroup>
+                        <!-- Left side: Search Input -->
+                        <span class="p-input-icon-left">
+            <i class="pi pi-search pr-2"> </i>
+            <p:inputText id="globalFilter" value="#{usersView.searchTerm}" placeholder="Search Users..." style="width: 250px;">
+                <p:ajax event="keyup" listener="#{usersView.reloadFilterReset}" update="usersTable" delay="150"/>
+            </p:inputText>
+        </span>
+                    </p:toolbarGroup>
+
+                    <p:toolbarGroup align="right">
+                        <!-- Right side: All Filters -->
+                        <div class="p-d-flex p-ai-center p-flex-wrap p-jc-end">
+                            <p:selectOneMenu id="departmentFilter" value="#{usersView.selectedDepartment}" converter="departmentConverter"
+                                             filter="true" filterMatchMode="contains" placeholder="All Departments"
+                                             styleClass="p-mr-2 p-mb-2" style="min-width: 12rem;">
+                                <f:selectItem itemLabel="All Departments" itemValue="#{null}" noSelectionOption="true"/>
+                                <f:selectItems value="#{usersView.departments}" var="dept" itemValue="#{dept}" itemLabel="#{dept.name}" />
+                                <p:ajax event="change" update="usersTable" listener="#{usersView.reloadFilterReset()}"/>
+                            </p:selectOneMenu>
+
+                            <p:selectOneMenu id="teamFilter" value="#{usersView.selectedTeam}" converter="teamConverter"
+                                             filter="true" filterMatchMode="contains" placeholder="All Teams"
+                                             styleClass="p-mr-2 p-mb-2" style="min-width: 12rem;">
+                                <f:selectItem itemLabel="All Teams" itemValue="#{null}" noSelectionOption="true"/>
+                                <f:selectItems value="#{usersView.teams}" var="team" itemValue="#{team}" itemLabel="#{team.name}" />
+                                <p:ajax event="change" update="usersTable" listener="#{usersView.reloadFilterReset()}"/>
+                            </p:selectOneMenu>
+
+                            <p:selectOneMenu id="roleFilter" value="#{usersView.selectedRole}" converter="roleConverter"
+                                             filter="true" filterMatchMode="contains" placeholder="All Roles"
+                                             styleClass="p-mr-2 p-mb-2" style="min-width: 12rem;">
+                                <f:selectItem itemLabel="All Roles" itemValue="#{null}" noSelectionOption="true"/>
+                                <f:selectItems value="#{usersView.roles}" var="role" itemValue="#{role}" itemLabel="#{role.name}" />
+                                <p:ajax event="change" update="usersTable" listener="#{usersView.reloadFilterReset()}"/>
+                            </p:selectOneMenu>
+
+                            <p:selectOneMenu id="genders" value="#{usersView.selectedGender}" converter="genderConverter"
+                                             placeholder="All Genders" styleClass="p-mr-2 p-mb-2" style="min-width: 10rem;">
+                                <f:selectItem itemLabel="All Genders" itemValue="#{null}" noSelectionOption="true"/>
+                                <f:selectItems value="#{usersView.genders}"/>
+                                <p:ajax event="change" update="usersTable" listener="#{usersView.reloadFilterReset()}"/>
+                            </p:selectOneMenu>
+
+<!--                            <p:calendar placeholder="From Date" value="#{usersView.createdFrom}" navigator="true" pattern="dd MMM, yyyy" styleClass="p-mr-2 p-mb-2"/>-->
+
+<!--                            <p:calendar placeholder="To Date" value="#{usersView.createdTo}" navigator="true" pattern="dd MMM, yyyy" styleClass="p-mr-2 p-mb-2"/>-->
+
+                            <p:commandButton icon="pi pi-search" styleClass="ui-button-info p-mb-2"
+                                             update="usersTable"
+                                             actionListener="#{usersView.reloadFilterReset()}"/>
+                        </div>
+                    </p:toolbarGroup>
+                </p:toolbar>
                 <p:dataTable id="usersTable" var="model" value="#{usersView.dataModels}"
                              widgetVar="usersTableWidget"
                              paginator="true" lazy="true" rows="10"
@@ -132,60 +187,6 @@
                              styleClass="users-table clickable-rows">
 
                     <p:ajax event="rowSelect" listener="#{usersView.viewUserProfile}" />
-
-                    <f:facet name="header">
-                        <div class="p-d-flex p-jc-between p-ai-center p-flex-wrap">
-                            <!-- Left side: Search Input -->
-                            <span class="p-input-icon-left p-mb-2">
-                                <i class="pi pi-search pr-2"></i>
-                                <p:inputText id="globalFilter" value="#{usersView.searchTerm}" placeholder="Search Users..." style="width: 250px;">
-                                    <p:ajax event="keyup" listener="#{usersView.reloadFilterReset}" update="usersTable" delay="300"/>
-                                </p:inputText>
-                            </span>
-
-                            <!-- Right side: All Filters -->
-                            <div class="p-d-flex p-ai-center p-flex-wrap p-jc-end">
-                                <p:selectOneMenu id="departmentFilter" value="#{usersView.selectedDepartment}" converter="departmentConverter"
-                                                 filter="true" filterMatchMode="contains" placeholder="All Departments"
-                                                 styleClass="p-mr-2 p-mb-2" style="min-width: 12rem;">
-                                    <f:selectItem itemLabel="All Departments" itemValue="#{null}" noSelectionOption="true"/>
-                                    <f:selectItems value="#{usersView.departments}" var="dept" itemValue="#{dept}" itemLabel="#{dept.name}" />
-                                    <p:ajax event="change" update="usersTable" listener="#{usersView.reloadFilterReset()}"/>
-                                </p:selectOneMenu>
-
-                                <p:selectOneMenu id="teamFilter" value="#{usersView.selectedTeam}" converter="teamConverter"
-                                                 filter="true" filterMatchMode="contains" placeholder="All Teams"
-                                                 styleClass="p-mr-2 p-mb-2" style="min-width: 12rem;">
-                                    <f:selectItem itemLabel="All Teams" itemValue="#{null}" noSelectionOption="true"/>
-                                    <f:selectItems value="#{usersView.teams}" var="team" itemValue="#{team}" itemLabel="#{team.name}" />
-                                    <p:ajax event="change" update="usersTable" listener="#{usersView.reloadFilterReset()}"/>
-                                </p:selectOneMenu>
-
-                                <p:selectOneMenu id="roleFilter" value="#{usersView.selectedRole}" converter="roleConverter"
-                                                 filter="true" filterMatchMode="contains" placeholder="All Roles"
-                                                 styleClass="p-mr-2 p-mb-2" style="min-width: 12rem;">
-                                    <f:selectItem itemLabel="All Roles" itemValue="#{null}" noSelectionOption="true"/>
-                                    <f:selectItems value="#{usersView.roles}" var="role" itemValue="#{role}" itemLabel="#{role.name}" />
-                                    <p:ajax event="change" update="usersTable" listener="#{usersView.reloadFilterReset()}"/>
-                                </p:selectOneMenu>
-
-                                <p:selectOneMenu id="genders" value="#{usersView.selectedGender}" converter="genderConverter"
-                                                 placeholder="All Genders" styleClass="p-mr-2 p-mb-2" style="min-width: 10rem;">
-                                    <f:selectItem itemLabel="All Genders" itemValue="#{null}" noSelectionOption="true"/>
-                                    <f:selectItems value="#{usersView.genders}"/>
-                                    <p:ajax event="change" update="usersTable" listener="#{usersView.reloadFilterReset()}"/>
-                                </p:selectOneMenu>
-
-                                <p:calendar placeholder="From Date" value="#{usersView.createdFrom}" navigator="true" pattern="dd MMM, yyyy" styleClass="p-mr-2 p-mb-2"/>
-
-                                <p:calendar placeholder="To Date" value="#{usersView.createdTo}" navigator="true" pattern="dd MMM, yyyy" styleClass="p-mr-2 p-mb-2"/>
-
-                                <p:commandButton icon="pi pi-search" styleClass="ui-button-info p-mb-2"
-                                                 update="usersTable"
-                                                 actionListener="#{usersView.reloadFilterReset()}"/>
-                            </div>
-                        </div>
-                    </f:facet>
 
                     <p:column headerText="User Info" sortBy="#{model.fullName}">
                         <div class="p-d-flex p-ai-center">


### PR DESCRIPTION
#### Description
=> When admin is viewing users and is typing into the search prompt to find a particular user, the prompt was always refreshing along with the table data refresh, making it hard to type a full name. Now its possible to type a full name without the prompt refreshing
#### Type of change
=> Please select the relevant option
- [ *] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Others (cosmetics, styling, improvements)
- [ ] This change requires a documentation update
#### How Has This Been Tested?
=> Please select the relevant option
- [* ] Unit
- [ ] Integration
- [ ] End-to-end
#### How can this be Tested?
=> Include the steps needed to test this PR
#### Any background context you want to add
